### PR TITLE
Fix: avoid extracting empty frame list

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -27,6 +27,7 @@ jobs:
         df -h
     - name: Install dependencies
       run: |
+        apt-get install ffmpeg
         python -m pip install --upgrade pip
         pip install -v -e .[all]
     - name: Increase swapfile

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -27,7 +27,7 @@ jobs:
         df -h
     - name: Install dependencies
       run: |
-        apt-get install ffmpeg
+        sudo apt-get install ffmpeg
         python -m pip install --upgrade pip
         pip install -v -e .[all]
     - name: Increase swapfile

--- a/data_juicer/utils/mm_utils.py
+++ b/data_juicer/utils/mm_utils.py
@@ -394,7 +394,8 @@ def process_each_frame(input_video: Union[str, av.container.InputContainer],
 
 def extract_key_frames(input_video: Union[str, av.container.InputContainer]):
     """
-    Extract key frames from the input video.
+    Extract key frames from the input video. If there is no keyframes in the
+    video, return the first frame.
 
     :param input_video: input video path or container.
     :return: a list of key frames.
@@ -414,11 +415,19 @@ def extract_key_frames(input_video: Union[str, av.container.InputContainer]):
     ori_skip_method = input_video_stream.codec_context.skip_frame
     input_video_stream.codec_context.skip_frame = 'NONKEY'
     # restore to the beginning of the video
-    container.seek(0, backward=False, any_frame=False)
+    container.seek(0)
     for frame in container.decode(input_video_stream):
         key_frames.append(frame)
     # restore to the original skip_type
     input_video_stream.codec_context.skip_frame = ori_skip_method
+
+    if len(key_frames) == 0:
+        logger.warning(f'No keyframes in this video [{input_video}]. Return '
+                       f'the first frame instead.')
+        container.seek(0)
+        for frame in container.decode(input_video_stream):
+            key_frames.append(frame)
+            break
 
     if isinstance(input_video, str):
         container.close()
@@ -514,7 +523,7 @@ def extract_video_frames_uniformly(
             continue
         if key_frame_second == 0.0:
             # search from the beginning
-            container.seek(0, backward=False, any_frame=True)
+            container.seek(0)
             search_idx = 0
             curr_pts = second_group[search_idx] / time_base
             for frame in container.decode(input_video_stream):

--- a/tests/config/test_config_funcs.py
+++ b/tests/config/test_config_funcs.py
@@ -41,6 +41,13 @@ class ConfigTest(DataJuicerTestCaseBase):
                         'text_key': 'text',
                         'image_key': 'images',
                         'audio_key': 'audios',
+                        'video_key': 'videos',
+                        'accelerator': 'cpu',
+                        'spec_numprocs': 0,
+                        'cpu_required': 1,
+                        'mem_required': 0,
+                        'use_actor': False,
+                        'batched_op': False,
                     }
                 }, 'nested dict load fail, for nonparametric op')
             self.assertDictEqual(
@@ -51,6 +58,12 @@ class ConfigTest(DataJuicerTestCaseBase):
                         'text_key': 'text',
                         'image_key': 'images',
                         'audio_key': 'audios',
+                        'video_key': 'videos',
+                        'accelerator': 'cpu',
+                        'spec_numprocs': 0,
+                        'cpu_required': 1,
+                        'mem_required': 0,
+                        'use_actor': False,
                     }
                 }, 'nested dict load fail, un-expected internal value')
 
@@ -83,6 +96,12 @@ class ConfigTest(DataJuicerTestCaseBase):
                         'text_key': 'text',
                         'image_key': 'images',
                         'audio_key': 'audios',
+                        'video_key': 'videos',
+                        'accelerator': 'cpu',
+                        'spec_numprocs': 0,
+                        'cpu_required': 1,
+                        'mem_required': 0,
+                        'use_actor': False,
                     }
                 })
             self.assertDictEqual(
@@ -93,6 +112,12 @@ class ConfigTest(DataJuicerTestCaseBase):
                         'text_key': 'text',
                         'image_key': 'images',
                         'audio_key': 'audios',
+                        'video_key': 'videos',
+                        'accelerator': 'cpu',
+                        'spec_numprocs': 0,
+                        'cpu_required': 1,
+                        'mem_required': 0,
+                        'use_actor': False,
                     }
                 })
             self.assertDictEqual(
@@ -103,6 +128,12 @@ class ConfigTest(DataJuicerTestCaseBase):
                         'text_key': 'text',
                         'image_key': 'images',
                         'audio_key': 'audios',
+                        'video_key': 'videos',
+                        'accelerator': 'cpu',
+                        'spec_numprocs': 0,
+                        'cpu_required': 1,
+                        'mem_required': 0,
+                        'use_actor': False,
                     }
                 })
             self.assertDictEqual(
@@ -113,6 +144,12 @@ class ConfigTest(DataJuicerTestCaseBase):
                         'text_key': 'text',
                         'image_key': 'images',
                         'audio_key': 'audios',
+                        'video_key': 'videos',
+                        'accelerator': 'cpu',
+                        'spec_numprocs': 0,
+                        'cpu_required': 1,
+                        'mem_required': 0,
+                        'use_actor': False,
                     }
                 })
             self.assertDictEqual(
@@ -123,6 +160,12 @@ class ConfigTest(DataJuicerTestCaseBase):
                         'text_key': 'text',
                         'image_key': 'images',
                         'audio_key': 'audios',
+                        'video_key': 'videos',
+                        'accelerator': 'cpu',
+                        'spec_numprocs': 0,
+                        'cpu_required': 1,
+                        'mem_required': 0,
+                        'use_actor': False,
                     }
                 })
 

--- a/tests/ops/mapper/test_image_diffusion_mapper.py
+++ b/tests/ops/mapper/test_image_diffusion_mapper.py
@@ -150,7 +150,7 @@ class ImageDiffusionMapperTest(DataJuicerTestCaseBase):
         dataset = NestedDataset.from_list(ds_list)
         op = ImageDiffusionMapper(hf_diffusion=self.hf_diffusion,
                                   torch_dtype='fp16',
-                                  revision='fp16'
+                                  revision='fp16',
                                   aug_num=aug_num,
                                   keep_original_sample=False,
                                   caption_key='text')


### PR DESCRIPTION
* Fix: avoid extracting empty key frame list
* Reopen Unittest for light OPs. Heavy OPs should be tested locally before pushed.