### PR TITLE
Example level error skipping.

### DIFF
--- a/data_juicer/ops/base_op.py
+++ b/data_juicer/ops/base_op.py
@@ -34,10 +34,9 @@ def catch_exception_mapper_process(method):
 
     def wrapper(self, *args, **kwargs):
         try:
-            sample = args[0]
             return method(self, *args, **kwargs)
         except Exception as e:
-            sample = copy.deepcopy(args[0])
+            sample = args[0]
             logger.error(
                 f'An error occurred in mapper operation when processing'
                 f'sample {sample}, {type(e)}: {e}')

--- a/data_juicer/ops/mapper/video_resize_aspect_ratio_mapper.py
+++ b/data_juicer/ops/mapper/video_resize_aspect_ratio_mapper.py
@@ -7,7 +7,9 @@ from data_juicer.utils.file_utils import transfer_filename
 from data_juicer.utils.logger_utils import HiddenPrints
 from data_juicer.utils.mm_utils import load_video
 
-from ..base_op import OPERATORS, Mapper
+from ..base_op import (OPERATORS, Mapper, catch_exception_mapper_process,
+                       convert_dict_list_to_list_dict,
+                       convert_list_dict_to_dict_list)
 
 OP_NAME = 'video_resize_aspect_ratio_mapper'
 
@@ -99,8 +101,14 @@ class VideoResizeAspectRatioMapper(Mapper):
         self.max_ratio = Fraction(str(max_ratio).replace(':', '/'))
         self.strategy = strategy
 
+        # added
+        self._batched_op = True
+
+    @catch_exception_mapper_process
     def process(self, sample):
         # there is no video in this sample
+        sample = convert_dict_list_to_list_dict(samples=sample,
+                                                text_key=self.text_key)[0]
         if self.video_key not in sample or not sample[self.video_key]:
             return sample
 
@@ -140,4 +148,5 @@ class VideoResizeAspectRatioMapper(Mapper):
             loaded_video_keys[index] = resized_video_key
 
         sample[self.video_key] = loaded_video_keys
-        return sample
+        res_sample = convert_list_dict_to_dict_list([sample])
+        return res_sample

--- a/data_juicer/ops/mapper/video_split_by_duration_mapper.py
+++ b/data_juicer/ops/mapper/video_split_by_duration_mapper.py
@@ -8,7 +8,7 @@ from data_juicer.utils.file_utils import (add_suffix_to_filename,
 from data_juicer.utils.mm_utils import (SpecialTokens, cut_video_by_seconds,
                                         get_video_duration, load_video)
 
-from ..base_op import OPERATORS, Mapper
+from ..base_op import OPERATORS, Mapper, catch_exception_mapper_process
 from ..op_fusion import LOADED_VIDEOS
 
 
@@ -132,6 +132,7 @@ class VideoSplitByDurationMapper(Mapper):
         split_sample[self.video_key] = split_video_keys
         return [split_sample]
 
+    @catch_exception_mapper_process
     def process(self, samples):
         # reconstruct samples from "dict of lists" to "list of dicts"
         reconstructed_samples = []


### PR DESCRIPTION
The PR here is an example of rewriting sample error catching.

The current data-juicer abruptly stops the program when an error arises due to an issue with a specific sample, which requires a direct rerun, and no outputs are exported. As shown in the image:
![image](https://github.com/modelscope/data-juicer/assets/46197280/e3d931ae-6357-486e-9040-5349f338efda)

After modification, errors caused by a specific sample will not interrupt the program; instead, exception handling will take place. The subsequent steps will continue to run and export the final outputs. As shown in the image:
![image](https://github.com/modelscope/data-juicer/assets/46197280/85c5c569-3071-4617-b1b5-b5b37be61c7d)


FUTURE TODOs:

- [ ] Expand to filters
- [ ] Optimize batch efficiency
- [ ] Improve the transmission of error messages