### PR TITLE
support loading op_config

### DIFF
--- a/tests/config/demo_4_test_sub.yaml
+++ b/tests/config/demo_4_test_sub.yaml
@@ -1,0 +1,15 @@
+# Process config example for Arxiv dataset
+
+# global parameters
+project_name: 'test_demo'
+dataset_path: './demos/data/demo-dataset.jsonl'  # path to your dataset directory or file
+np: 4  # number of subprocess to process your dataset
+
+export_path: './outputs/demo/demo-processed.parquet'
+
+# process schedule
+# a list of several process operators with their arguments
+process:
+  - document_deduplicator: # deduplicate text samples using md5 hashing exact matching method
+      lowercase: false   # whether to convert text to lower case
+      op_config: ./tests/config/sub_op_config.yaml

--- a/tests/config/sub_op_config.yaml
+++ b/tests/config/sub_op_config.yaml
@@ -1,0 +1,2 @@
+lowercase: true    # will be overwritten
+ignore_non_character: true

--- a/tests/config/test_config_funcs.py
+++ b/tests/config/test_config_funcs.py
@@ -11,7 +11,8 @@ from data_juicer.utils.unittest_utils import DataJuicerTestCaseBase
 
 test_yaml_path = os.path.join(os.path.dirname(os.path.realpath(__file__)),
                               'demo_4_test.yaml')
-
+test_sub_yaml_path = os.path.join(os.path.dirname(os.path.realpath(__file__)),
+                              'demo_4_test_sub.yaml')
 test_bad_yaml_path = os.path.join(os.path.dirname(os.path.realpath(__file__)),
                               'demo_4_test_bad_val.yaml')
 
@@ -73,6 +74,29 @@ class ConfigTest(DataJuicerTestCaseBase):
 
             _, op_from_cfg = load_ops(cfg.process)
             self.assertTrue(len(op_from_cfg) == 3)
+
+    def test_sub_yaml_cfg_file(self):
+        out = StringIO()
+        with redirect_stdout(out):
+            cfg = init_configs(args=f'--config {test_sub_yaml_path}'.split())
+            self.assertDictEqual(
+                cfg.process[0], {
+                    'document_deduplicator': {
+                        'lowercase': False,
+                        'ignore_non_character': True,
+                        'text_key': 'text',
+                        'image_key': 'images',
+                        'audio_key': 'audios',
+                        'video_key': 'videos',
+                        'accelerator': 'cpu',
+                        'spec_numprocs': 0,
+                        'cpu_required': 1,
+                        'mem_required': 0,
+                        'use_actor': False,
+                    }
+                })
+            _, op_from_cfg = load_ops(cfg.process)
+            self.assertTrue(len(op_from_cfg) == 1)
 
     def test_val_range_check_cmd(self):
         out = StringIO()


### PR DESCRIPTION
- Each `OP` in `process` accepts a new `op_config` argument to load configurations from another YAML file.
- Command line also allows OP-specific configuration, e.g., `python tools/process_data.py --config configs/demo/process.yaml --language_id_score_filter op_conf.yaml --language_id_score_filter.min_score 0.6`

The precedence for overrides is: command-line args from left to right > args in main YMAL >  args in sub-op YAML