### PR TITLE
Sample level error catching

### DIFF
--- a/data_juicer/ops/base_op.py
+++ b/data_juicer/ops/base_op.py
@@ -34,10 +34,9 @@ def catch_exception_mapper_process(method):
 
     def wrapper(self, *args, **kwargs):
         try:
-            sample = args[0]
             return method(self, *args, **kwargs)
         except Exception as e:
-            sample = copy.deepcopy(args[0])
+            sample = args[0]
             logger.error(
                 f'An error occurred in mapper operation when processing'
                 f'sample {sample}, {type(e)}: {e}')

--- a/data_juicer/ops/base_op.py
+++ b/data_juicer/ops/base_op.py
@@ -169,7 +169,9 @@ class Mapper(OP):
         super(Mapper, self).__init__(*args, **kwargs)
 
         # In default, it's a normal OP instead of batched OP
-        self._batched_op = kwargs.get('batched_op', False)
+        # self._batched_op = kwargs.get('batched_op', False)
+        # Aftet the refactor, we want all ops to be batched OP by default
+        self._batched_op = kwargs.get('batched_op', True)
 
     def process(self, sample):
         """

--- a/data_juicer/ops/mapper/audio_ffmpeg_wrapped_mapper.py
+++ b/data_juicer/ops/mapper/audio_ffmpeg_wrapped_mapper.py
@@ -4,7 +4,7 @@ from data_juicer.utils.availability_utils import AvailabilityChecking
 from data_juicer.utils.file_utils import transfer_filename
 from data_juicer.utils.logger_utils import HiddenPrints
 
-from ..base_op import OPERATORS, Mapper
+from ..base_op import OPERATORS, Mapper, catch_exception_mapper_process_single
 
 OP_NAME = 'audio_ffmpeg_wrapped_mapper'
 
@@ -47,8 +47,8 @@ class AudioFFmpegWrappedMapper(Mapper):
         self.capture_stderr = capture_stderr
         self.overwrite_output = overwrite_output
 
-    def process(self, sample):
-        # there is no audio in this sample
+    @catch_exception_mapper_process_single
+    def process(self, sample):  # there is no audio in this sample
         if self.audio_key not in sample or not sample[self.audio_key]:
             return sample
 

--- a/data_juicer/ops/mapper/clean_copyright_mapper.py
+++ b/data_juicer/ops/mapper/clean_copyright_mapper.py
@@ -4,7 +4,7 @@
 
 import regex as re
 
-from ..base_op import OPERATORS, Mapper
+from ..base_op import OPERATORS, Mapper, catch_exception_mapper_process_single
 
 
 @OPERATORS.register_module('clean_copyright_mapper')
@@ -23,8 +23,8 @@ class CleanCopyrightMapper(Mapper):
         self.pat = re.compile('/\\*[^*]*\\*+(?:[^/*][^*]*\\*+)*/')
         self.cpat = re.compile('copyright', re.IGNORECASE)
 
+    @catch_exception_mapper_process_single
     def process(self, sample):
-
         r = self.pat.search(sample[self.text_key])
         if r:
             # found one, now see if it contains "copyright", if so strip it

--- a/data_juicer/ops/mapper/clean_email_mapper.py
+++ b/data_juicer/ops/mapper/clean_email_mapper.py
@@ -1,6 +1,6 @@
 import regex as re
 
-from ..base_op import OPERATORS, Mapper
+from ..base_op import OPERATORS, Mapper, catch_exception_mapper_process_single
 
 
 @OPERATORS.register_module('clean_email_mapper')
@@ -28,8 +28,8 @@ class CleanEmailMapper(Mapper):
 
         self.repl = repl
 
+    @catch_exception_mapper_process_single
     def process(self, sample):
-
         if not re.search(self.pattern, sample[self.text_key], flags=re.DOTALL):
             return sample
 

--- a/data_juicer/ops/mapper/clean_html_mapper.py
+++ b/data_juicer/ops/mapper/clean_html_mapper.py
@@ -4,7 +4,7 @@
 
 from data_juicer.utils.availability_utils import AvailabilityChecking
 
-from ..base_op import OPERATORS, Mapper
+from ..base_op import OPERATORS, Mapper, catch_exception_mapper_process_single
 
 OP_NAME = 'clean_html_mapper'
 
@@ -25,6 +25,7 @@ class CleanHtmlMapper(Mapper):
         """
         super().__init__(*args, **kwargs)
 
+    @catch_exception_mapper_process_single
     def process(self, sample):
 
         def _clean_html(raw_html):

--- a/data_juicer/ops/mapper/clean_ip_mapper.py
+++ b/data_juicer/ops/mapper/clean_ip_mapper.py
@@ -1,6 +1,6 @@
 import regex as re
 
-from ..base_op import OPERATORS, Mapper
+from ..base_op import OPERATORS, Mapper, catch_exception_mapper_process_single
 
 
 @OPERATORS.register_module('clean_ip_mapper')
@@ -32,8 +32,8 @@ class CleanIpMapper(Mapper):
                 self.pattern = pattern[2:-1]
         self.repl = repl
 
+    @catch_exception_mapper_process_single
     def process(self, sample):
-
         if not re.search(self.pattern, sample[self.text_key], flags=re.DOTALL):
             return sample
 

--- a/data_juicer/ops/mapper/clean_links_mapper.py
+++ b/data_juicer/ops/mapper/clean_links_mapper.py
@@ -3,7 +3,7 @@
 # --------------------------------------------------------
 import regex as re
 
-from ..base_op import OPERATORS, Mapper
+from ..base_op import OPERATORS, Mapper, catch_exception_mapper_process_single
 
 
 @OPERATORS.register_module('clean_links_mapper')
@@ -38,8 +38,8 @@ class CleanLinksMapper(Mapper):
                 self.pattern = pattern[2:-1]
         self.repl = repl
 
+    @catch_exception_mapper_process_single
     def process(self, sample):
-
         if not re.search(self.pattern, sample[self.text_key], flags=re.DOTALL):
             return sample
 

--- a/data_juicer/ops/mapper/expand_macro_mapper.py
+++ b/data_juicer/ops/mapper/expand_macro_mapper.py
@@ -4,7 +4,7 @@
 
 import regex as re
 
-from ..base_op import OPERATORS, Mapper
+from ..base_op import OPERATORS, Mapper, catch_exception_mapper_process_single
 
 
 @OPERATORS.register_module('expand_macro_mapper')
@@ -55,6 +55,7 @@ class ExpandMacroMapper(Mapper):
                 macros[macro_name] = macro_val
         return macros
 
+    @catch_exception_mapper_process_single
     def process(self, sample):
         non_arg_macros = self._build_non_arg_macros_dict(sample[self.text_key])
 

--- a/data_juicer/ops/mapper/fix_unicode_mapper.py
+++ b/data_juicer/ops/mapper/fix_unicode_mapper.py
@@ -1,6 +1,6 @@
 from data_juicer.utils.availability_utils import AvailabilityChecking
 
-from ..base_op import OPERATORS, Mapper
+from ..base_op import OPERATORS, Mapper, catch_exception_mapper_process_single
 
 OP_NAME = 'fix_unicode_mapper'
 
@@ -33,6 +33,7 @@ class FixUnicodeMapper(Mapper):
                              'supported. Can only be one of '
                              '["NFC", "NFKC", "NFD", "NFKD"]')
 
+    @catch_exception_mapper_process_single
     def process(self, sample):
         sample[self.text_key] = ftfy.fix_text(sample[self.text_key],
                                               normalization=self.normalization)

--- a/data_juicer/ops/mapper/image_blur_mapper.py
+++ b/data_juicer/ops/mapper/image_blur_mapper.py
@@ -6,7 +6,7 @@ from data_juicer.utils.constant import Fields
 from data_juicer.utils.file_utils import transfer_filename
 from data_juicer.utils.mm_utils import load_data_with_context, load_image
 
-from ..base_op import OPERATORS, Mapper
+from ..base_op import OPERATORS, Mapper, catch_exception_mapper_process_single
 from ..op_fusion import LOADED_IMAGES
 
 OP_NAME = 'image_blur_mapper'
@@ -53,6 +53,7 @@ class ImageBlurMapper(Mapper):
         else:
             self.blur = ImageFilter.GaussianBlur(radius)
 
+    @catch_exception_mapper_process_single
     def process(self, sample, context=False):
         # there is no image in this sample
         if self.image_key not in sample or not sample[self.image_key]:

--- a/data_juicer/ops/mapper/image_captioning_from_gpt4v_mapper.py
+++ b/data_juicer/ops/mapper/image_captioning_from_gpt4v_mapper.py
@@ -10,7 +10,7 @@ from data_juicer.utils.mm_utils import (SpecialTokens, image_byte_to_base64,
                                         remove_non_special_tokens,
                                         remove_special_tokens)
 
-from ..base_op import OPERATORS, Mapper
+from ..base_op import OPERATORS, Mapper, catch_exception_mapper_process
 from ..op_fusion import LOADED_IMAGES
 
 SYSTEM_PROMPTS = {
@@ -244,6 +244,7 @@ class ImageCaptioningFromGPT4VMapper(Mapper):
 
         return [generated_sample]
 
+    @catch_exception_mapper_process
     def process(self, samples):
         # reconstruct samples from "dict of lists" to "list of dicts"
         reconstructed_samples = []

--- a/data_juicer/ops/mapper/image_captioning_mapper.py
+++ b/data_juicer/ops/mapper/image_captioning_mapper.py
@@ -13,7 +13,7 @@ from data_juicer.utils.mm_utils import (SpecialTokens,
                                         remove_special_tokens)
 from data_juicer.utils.model_utils import get_model, prepare_model
 
-from ..base_op import OPERATORS, Mapper
+from ..base_op import OPERATORS, Mapper, catch_exception_mapper_process
 from ..op_fusion import LOADED_IMAGES
 
 OP_NAME = 'image_captioning_mapper'
@@ -272,6 +272,7 @@ class ImageCaptioningMapper(Mapper):
                 generated_text_candidates_single_chunk[max_index])
         return new_generated_text_per_chunk
 
+    @catch_exception_mapper_process
     def process(self, samples, rank=None):
         """
         Note:

--- a/data_juicer/ops/mapper/image_diffusion_mapper.py
+++ b/data_juicer/ops/mapper/image_diffusion_mapper.py
@@ -10,7 +10,7 @@ from data_juicer.utils.mm_utils import (SpecialTokens, load_data_with_context,
                                         load_image, remove_special_tokens)
 from data_juicer.utils.model_utils import get_model, prepare_model
 
-from ..base_op import OPERATORS, Mapper
+from ..base_op import OPERATORS, Mapper, catch_exception_mapper_process
 from ..op_fusion import LOADED_IMAGES
 
 OP_NAME = 'image_diffusion_mapper'
@@ -209,6 +209,7 @@ class ImageDiffusionMapper(Mapper):
 
         return generated_samples
 
+    @catch_exception_mapper_process
     def process(self, samples, rank=None, context=False):
         """
             Note:

--- a/data_juicer/ops/mapper/image_face_blur_mapper.py
+++ b/data_juicer/ops/mapper/image_face_blur_mapper.py
@@ -6,7 +6,7 @@ from data_juicer.utils.file_utils import transfer_filename
 from data_juicer.utils.mm_utils import (load_data_with_context, load_image,
                                         pil_to_opencv)
 
-from ..base_op import OPERATORS, Mapper
+from ..base_op import OPERATORS, Mapper, catch_exception_mapper_process_single
 from ..op_fusion import LOADED_IMAGES
 
 OP_NAME = 'image_face_blur_mapper'
@@ -66,6 +66,7 @@ class ImageFaceBlurMapper(Mapper):
         # Initialize face detector
         self.detector = dlib.get_frontal_face_detector()
 
+    @catch_exception_mapper_process_single
     def process(self, sample, context=False):
         # there is no image in this sample
         if self.image_key not in sample or not sample[self.image_key]:

--- a/data_juicer/ops/mapper/nlpaug_en_mapper.py
+++ b/data_juicer/ops/mapper/nlpaug_en_mapper.py
@@ -4,7 +4,7 @@ from loguru import logger
 
 from data_juicer.utils.availability_utils import AvailabilityChecking
 
-from ..base_op import OPERATORS, Mapper
+from ..base_op import OPERATORS, Mapper, catch_exception_mapper_process_single
 
 OP_NAME = 'nlpaug_en_mapper'
 
@@ -122,6 +122,7 @@ class NlpaugEnMapper(Mapper):
         else:
             self.aug = aug_pipeline
 
+    @catch_exception_mapper_process_single
     def process(self, samples):
         # no augmentation methods are opened
         if len(self.aug) == 0:

--- a/data_juicer/ops/mapper/nlpaug_en_mapper.py
+++ b/data_juicer/ops/mapper/nlpaug_en_mapper.py
@@ -4,7 +4,7 @@ from loguru import logger
 
 from data_juicer.utils.availability_utils import AvailabilityChecking
 
-from ..base_op import OPERATORS, Mapper, catch_exception_mapper_process_single
+from ..base_op import OPERATORS, Mapper, catch_exception_mapper_process
 
 OP_NAME = 'nlpaug_en_mapper'
 
@@ -122,7 +122,7 @@ class NlpaugEnMapper(Mapper):
         else:
             self.aug = aug_pipeline
 
-    @catch_exception_mapper_process_single
+    @catch_exception_mapper_process
     def process(self, samples):
         # no augmentation methods are opened
         if len(self.aug) == 0:

--- a/data_juicer/ops/mapper/nlpcda_zh_mapper.py
+++ b/data_juicer/ops/mapper/nlpcda_zh_mapper.py
@@ -5,7 +5,7 @@ from loguru import logger
 from data_juicer.utils.availability_utils import AvailabilityChecking
 from data_juicer.utils.logger_utils import HiddenPrints
 
-from ..base_op import OPERATORS, Mapper
+from ..base_op import OPERATORS, Mapper, catch_exception_mapper_process
 
 OP_NAME = 'nlpcda_zh_mapper'
 
@@ -128,6 +128,7 @@ class NlpcdaZhMapper(Mapper):
                 self.aug_pipeline.append(
                     nlpcda.EquivalentChar(create_num=create_num))
 
+    @catch_exception_mapper_process
     def process(self, samples):
         # no augmentation methods are opened
         if len(self.aug_pipeline) == 0:

--- a/data_juicer/ops/mapper/punctuation_normalization_mapper.py
+++ b/data_juicer/ops/mapper/punctuation_normalization_mapper.py
@@ -2,7 +2,7 @@
 # https://github.com/bigscience-workshop/data-preparation
 # --------------------------------------------------------
 
-from ..base_op import OPERATORS, Mapper
+from ..base_op import OPERATORS, Mapper, catch_exception_mapper_process_single
 
 
 @OPERATORS.register_module('punctuation_normalization_mapper')
@@ -55,6 +55,7 @@ class PunctuationNormalizationMapper(Mapper):
             '►': '-',
         }
 
+    @catch_exception_mapper_process_single
     def process(self, sample):
         sample[self.text_key] = ''.join([
             self.punctuation_unicode.get(c, c) for c in sample[self.text_key]

--- a/data_juicer/ops/mapper/remove_bibliography_mapper.py
+++ b/data_juicer/ops/mapper/remove_bibliography_mapper.py
@@ -4,7 +4,7 @@
 
 import regex as re
 
-from ..base_op import OPERATORS, Mapper
+from ..base_op import OPERATORS, Mapper, catch_exception_mapper_process_single
 
 
 @OPERATORS.register_module('remove_bibliography_mapper')
@@ -27,6 +27,7 @@ class RemoveBibliographyMapper(Mapper):
         self.pattern += r'\\bibliography\{.*\}'
         self.pattern += r').*$'
 
+    @catch_exception_mapper_process_single
     def process(self, sample):
         sample[self.text_key] = re.sub(pattern=self.pattern,
                                        repl=r'',

--- a/data_juicer/ops/mapper/remove_comments_mapper.py
+++ b/data_juicer/ops/mapper/remove_comments_mapper.py
@@ -6,7 +6,7 @@ from typing import List, Union
 
 import regex as re
 
-from ..base_op import OPERATORS, Mapper
+from ..base_op import OPERATORS, Mapper, catch_exception_mapper_process_single
 
 
 @OPERATORS.register_module('remove_comments_mapper')
@@ -37,6 +37,7 @@ class RemoveCommentsMapper(Mapper):
         self.inline = inline
         self.multiline = multiline
 
+    @catch_exception_mapper_process_single
     def process(self, sample):
         # TODO: remove different comments by sample type
 

--- a/data_juicer/ops/mapper/remove_header_mapper.py
+++ b/data_juicer/ops/mapper/remove_header_mapper.py
@@ -4,7 +4,7 @@
 
 import regex as re
 
-from ..base_op import OPERATORS, Mapper
+from ..base_op import OPERATORS, Mapper, catch_exception_mapper_process_single
 
 
 @OPERATORS.register_module('remove_header_mapper')
@@ -34,8 +34,8 @@ class RemoveHeaderMapper(Mapper):
 
         self.drop_no_head = drop_no_head
 
+    @catch_exception_mapper_process_single
     def process(self, sample):
-
         if not re.search(self.pattern, sample[self.text_key], flags=re.DOTALL):
             if self.drop_no_head:
                 sample[self.text_key] = ''

--- a/data_juicer/ops/mapper/remove_long_words_mapper.py
+++ b/data_juicer/ops/mapper/remove_long_words_mapper.py
@@ -6,7 +6,7 @@ import sys
 
 from jsonargparse.typing import PositiveInt
 
-from ..base_op import OPERATORS, Mapper
+from ..base_op import OPERATORS, Mapper, catch_exception_mapper_process_single
 from ..common import (SPECIAL_CHARACTERS, merge_on_whitespace_tab_newline,
                       split_on_newline_tab_whitespace, strip)
 
@@ -43,8 +43,8 @@ class RemoveLongWordsMapper(Mapper):
         else:
             return False
 
+    @catch_exception_mapper_process_single
     def process(self, sample):
-
         sentences = split_on_newline_tab_whitespace(sample[self.text_key])
         sentences = [[[
             word for word in subsentence if self.should_keep_long_word(word)

--- a/data_juicer/ops/mapper/remove_non_chinese_character_mapper.py
+++ b/data_juicer/ops/mapper/remove_non_chinese_character_mapper.py
@@ -1,6 +1,6 @@
 import regex as re
 
-from ..base_op import OPERATORS, Mapper
+from ..base_op import OPERATORS, Mapper, catch_exception_mapper_process_single
 
 
 @OPERATORS.register_module('remove_non_chinese_character_mapper')
@@ -33,8 +33,8 @@ class RemoveNonChineseCharacterlMapper(Mapper):
         else:
             self.pattern += u']'
 
+    @catch_exception_mapper_process_single
     def process(self, sample):
-
         if not re.search(self.pattern, sample[self.text_key], flags=re.DOTALL):
             return sample
 

--- a/data_juicer/ops/mapper/remove_repeat_sentences_mapper.py
+++ b/data_juicer/ops/mapper/remove_repeat_sentences_mapper.py
@@ -1,6 +1,6 @@
 import regex as re
 
-from ..base_op import OPERATORS, Mapper
+from ..base_op import OPERATORS, Mapper, catch_exception_mapper_process_single
 
 
 def split_sentence(text):
@@ -43,8 +43,8 @@ class RemoveRepeatSentencesMapper(Mapper):
         self.remove_regex = re.compile(r'[^a-zA-Z0-9\u4e00-\u9fa5\n\t ]'
                                        ) if ignore_special_character else None
 
+    @catch_exception_mapper_process_single
     def process(self, sample):
-
         lines = [e for e in sample[self.text_key].split('\n')]
         new_lines = []
         hash_set = set([])

--- a/data_juicer/ops/mapper/remove_specific_chars_mapper.py
+++ b/data_juicer/ops/mapper/remove_specific_chars_mapper.py
@@ -2,7 +2,7 @@ from typing import List, Union
 
 import regex as re
 
-from ..base_op import OPERATORS, Mapper
+from ..base_op import OPERATORS, Mapper, catch_exception_mapper_process_single
 
 
 @OPERATORS.register_module('remove_specific_chars_mapper')
@@ -28,8 +28,8 @@ class RemoveSpecificCharsMapper(Mapper):
         else:
             self.pattern = None
 
+    @catch_exception_mapper_process_single
     def process(self, sample):
-
         if self.pattern is None:
             return sample
 

--- a/data_juicer/ops/mapper/remove_table_text_mapper.py
+++ b/data_juicer/ops/mapper/remove_table_text_mapper.py
@@ -1,7 +1,7 @@
 import regex as re
 from jsonargparse.typing import restricted_number_type
 
-from ..base_op import OPERATORS, Mapper
+from ..base_op import OPERATORS, Mapper, catch_exception_mapper_process_single
 
 from_2_to_20 = restricted_number_type('from_2_to_20', int, [('>=', 2),
                                                             ('<=', 20)])
@@ -34,8 +34,8 @@ class RemoveTableTextMapper(Mapper):
         self.max_col = max_col
         self.pattern = r'(?<=\n)((\S+?)([ |\t](\S+?)){%d}\n+){2,}'
 
+    @catch_exception_mapper_process_single
     def process(self, sample):
-
         text = sample[self.text_key]
         for i in range(self.min_col - 1, self.max_col):
             pattern = re.compile(self.pattern % i)

--- a/data_juicer/ops/mapper/remove_words_with_incorrect_substrings_mapper.py
+++ b/data_juicer/ops/mapper/remove_words_with_incorrect_substrings_mapper.py
@@ -3,7 +3,7 @@ from jsonargparse.typing import List
 from data_juicer.utils.availability_utils import AvailabilityChecking
 from data_juicer.utils.model_utils import get_model, prepare_model
 
-from ..base_op import OPERATORS, Mapper
+from ..base_op import OPERATORS, Mapper, catch_exception_mapper_process_single
 from ..common import (SPECIAL_CHARACTERS, get_words_from_document,
                       merge_on_whitespace_tab_newline,
                       split_on_newline_tab_whitespace, strip)
@@ -48,6 +48,7 @@ class RemoveWordsWithIncorrectSubstringsMapper(Mapper):
         should_keep = all([(i_substr not in word) for i_substr in substrings])
         return should_keep
 
+    @catch_exception_mapper_process_single
     def process(self, sample):
         if self.tokenization:
             tokenizer = get_model(self.model_key)

--- a/data_juicer/ops/mapper/replace_content_mapper.py
+++ b/data_juicer/ops/mapper/replace_content_mapper.py
@@ -1,6 +1,6 @@
 import regex as re
 
-from ..base_op import OPERATORS, Mapper
+from ..base_op import OPERATORS, Mapper, catch_exception_mapper_process_single
 
 
 @OPERATORS.register_module('replace_content_mapper')
@@ -26,8 +26,8 @@ class ReplaceContentMapper(Mapper):
             self.pattern = pattern[2:-1]
         self.repl = repl
 
+    @catch_exception_mapper_process_single
     def process(self, sample):
-
         if self.pattern is None:
             return sample
 

--- a/data_juicer/ops/mapper/sentence_split_mapper.py
+++ b/data_juicer/ops/mapper/sentence_split_mapper.py
@@ -1,7 +1,7 @@
 from data_juicer.utils.availability_utils import AvailabilityChecking
 from data_juicer.utils.model_utils import get_model, prepare_model
 
-from ..base_op import OPERATORS, Mapper
+from ..base_op import OPERATORS, Mapper, catch_exception_mapper_process_single
 from ..common import get_sentences_from_document
 
 OP_NAME = 'sentence_split_mapper'
@@ -26,8 +26,8 @@ class SentenceSplitMapper(Mapper):
         self.lang = lang
         self.model_key = prepare_model(model_type='nltk', lang=lang)
 
+    @catch_exception_mapper_process_single
     def process(self, sample):
-
         nltk_model = get_model(self.model_key)
         sample[self.text_key] = get_sentences_from_document(
             sample[self.text_key],

--- a/data_juicer/ops/mapper/video_captioning_from_audio_mapper.py
+++ b/data_juicer/ops/mapper/video_captioning_from_audio_mapper.py
@@ -7,7 +7,7 @@ from data_juicer.utils.availability_utils import AvailabilityChecking
 from data_juicer.utils.mm_utils import SpecialTokens, extract_audio_from_video
 from data_juicer.utils.model_utils import get_model, prepare_model
 
-from ..base_op import OPERATORS, Mapper
+from ..base_op import OPERATORS, Mapper, catch_exception_mapper_process
 
 NAME = 'video_captioning_from_audio_mapper'
 CHECK_PKGS = [
@@ -122,6 +122,7 @@ class VideoCaptioningFromAudioMapper(Mapper):
         captioned_sample[self.video_key] = left_video_keys
         return [captioned_sample]
 
+    @catch_exception_mapper_process
     def process(self, samples, rank=None):
         # reconstruct samples from "dict of lists" to "list of dicts"
         reconstructed_samples = []

--- a/data_juicer/ops/mapper/video_captioning_from_frames_mapper.py
+++ b/data_juicer/ops/mapper/video_captioning_from_frames_mapper.py
@@ -16,7 +16,7 @@ from data_juicer.utils.mm_utils import (SpecialTokens, extract_key_frames,
                                         remove_special_tokens)
 from data_juicer.utils.model_utils import get_model, prepare_model
 
-from ..base_op import OPERATORS, Mapper
+from ..base_op import OPERATORS, Mapper, catch_exception_mapper_process
 from ..op_fusion import LOADED_VIDEOS
 
 OP_NAME = 'video_captioning_from_frames_mapper'
@@ -329,6 +329,7 @@ class VideoCaptioningFromFramesMapper(Mapper):
                 generated_text_candidates_single_chunk[max_index])
         return generated_text_per_chunk
 
+    @catch_exception_mapper_process
     def process(self, samples, rank=None, context=False):
         """
         :param samples:

--- a/data_juicer/ops/mapper/video_captioning_from_summarizer_mapper.py
+++ b/data_juicer/ops/mapper/video_captioning_from_summarizer_mapper.py
@@ -8,7 +8,7 @@ from data_juicer.utils.constant import Fields
 from data_juicer.utils.mm_utils import SpecialTokens, remove_special_tokens
 from data_juicer.utils.model_utils import get_model, prepare_model
 
-from ..base_op import OPERATORS, Mapper
+from ..base_op import OPERATORS, Mapper, catch_exception_mapper_process
 
 NAME = 'video_captioning_from_summarizer_mapper'
 CHECK_PKGS = [
@@ -249,6 +249,7 @@ class VideoCaptioningFromSummarizerMapper(Mapper):
         captioned_sample[self.text_key] = captioned_texts
         return [captioned_sample]
 
+    @catch_exception_mapper_process
     def process(self, samples, rank=None):
         # reconstruct samples from "dict of lists" to "list of dicts"
         reconstructed_samples = []

--- a/data_juicer/ops/mapper/video_captioning_from_video_mapper.py
+++ b/data_juicer/ops/mapper/video_captioning_from_video_mapper.py
@@ -16,7 +16,7 @@ from data_juicer.utils.mm_utils import (SpecialTokens, extract_key_frames,
                                         remove_special_tokens)
 from data_juicer.utils.model_utils import get_model, prepare_model
 
-from ..base_op import OPERATORS, Mapper
+from ..base_op import OPERATORS, Mapper, catch_exception_mapper_process
 from ..op_fusion import LOADED_VIDEOS
 
 OP_NAME = 'video_captioning_from_video_mapper'
@@ -336,6 +336,7 @@ class VideoCaptioningFromVideoMapper(Mapper):
                 generated_text_candidates_single_chunk[max_index])
         return generated_text_per_chunk
 
+    @catch_exception_mapper_process
     def process(self, samples, rank=None, context=False):
         """
         :param samples:

--- a/data_juicer/ops/mapper/video_face_blur_mapper.py
+++ b/data_juicer/ops/mapper/video_face_blur_mapper.py
@@ -5,7 +5,7 @@ from data_juicer.utils.file_utils import transfer_filename
 from data_juicer.utils.mm_utils import (load_data_with_context, load_video,
                                         pil_to_opencv, process_each_frame)
 
-from ..base_op import OPERATORS, Mapper
+from ..base_op import OPERATORS, Mapper, catch_exception_mapper_process_single
 from ..op_fusion import LOADED_VIDEOS
 
 OP_NAME = 'video_face_blur_mapper'
@@ -65,6 +65,7 @@ class VideoFaceBlurMapper(Mapper):
         # Initialize face detector
         self.detector = dlib.get_frontal_face_detector()
 
+    @catch_exception_mapper_process_single
     def process(self, sample, context=False):
         # there is no video in this sample
         if self.video_key not in sample or not sample[self.video_key]:

--- a/data_juicer/ops/mapper/video_ffmpeg_wrapped_mapper.py
+++ b/data_juicer/ops/mapper/video_ffmpeg_wrapped_mapper.py
@@ -4,7 +4,7 @@ from data_juicer.utils.availability_utils import AvailabilityChecking
 from data_juicer.utils.file_utils import transfer_filename
 from data_juicer.utils.logger_utils import HiddenPrints
 
-from ..base_op import OPERATORS, Mapper
+from ..base_op import OPERATORS, Mapper, catch_exception_mapper_process_single
 
 OP_NAME = 'video_ffmpeg_wrapped_mapper'
 
@@ -47,8 +47,8 @@ class VideoFFmpegWrappedMapper(Mapper):
         self.capture_stderr = capture_stderr
         self.overwrite_output = overwrite_output
 
-    def process(self, sample):
-        # there is no video in this sample
+    @catch_exception_mapper_process_single
+    def process(self, sample):  # there is no video in this sample
         if self.video_key not in sample or not sample[self.video_key]:
             return sample
 

--- a/data_juicer/ops/mapper/video_remove_watermark_mapper.py
+++ b/data_juicer/ops/mapper/video_remove_watermark_mapper.py
@@ -12,7 +12,7 @@ from data_juicer.utils.mm_utils import (extract_video_frames_uniformly,
                                         parse_string_to_roi,
                                         process_each_frame)
 
-from ..base_op import OPERATORS, Mapper
+from ..base_op import OPERATORS, Mapper, catch_exception_mapper_process_single
 from ..op_fusion import LOADED_VIDEOS
 
 OP_NAME = 'video_remove_watermark_mapper'
@@ -199,6 +199,7 @@ class VideoRemoveWatermarkMapper(Mapper):
         new_np_frame = cv.inpaint(np_frame, watermark_mask, 3, cv.INPAINT_NS)
         return av.VideoFrame.from_ndarray(new_np_frame, format='bgr24')
 
+    @catch_exception_mapper_process_single
     def process(self, sample, context=False):
         # there is no video in this sample
         if self.video_key not in sample or not sample[self.video_key]:

--- a/data_juicer/ops/mapper/video_resize_aspect_ratio_mapper.py
+++ b/data_juicer/ops/mapper/video_resize_aspect_ratio_mapper.py
@@ -98,12 +98,10 @@ class VideoResizeAspectRatioMapper(Mapper):
         self.min_ratio = Fraction(str(min_ratio).replace(':', '/'))
         self.max_ratio = Fraction(str(max_ratio).replace(':', '/'))
         self.strategy = strategy
-        self._batched_op = True
 
     # turned into batched processing and with catch
     @catch_exception_mapper_process_single
-    def process(self, sample):
-        # there is no video in this sample
+    def process(self, sample):  # there is no video in this sample
         if self.video_key not in sample or not sample[self.video_key]:
             return sample
 

--- a/data_juicer/ops/mapper/video_resize_aspect_ratio_mapper.py
+++ b/data_juicer/ops/mapper/video_resize_aspect_ratio_mapper.py
@@ -7,7 +7,9 @@ from data_juicer.utils.file_utils import transfer_filename
 from data_juicer.utils.logger_utils import HiddenPrints
 from data_juicer.utils.mm_utils import load_video
 
-from ..base_op import OPERATORS, Mapper
+from ..base_op import (OPERATORS, Mapper, catch_exception_mapper_process,
+                       convert_dict_list_to_list_dict,
+                       convert_list_dict_to_dict_list)
 
 OP_NAME = 'video_resize_aspect_ratio_mapper'
 
@@ -99,8 +101,14 @@ class VideoResizeAspectRatioMapper(Mapper):
         self.max_ratio = Fraction(str(max_ratio).replace(':', '/'))
         self.strategy = strategy
 
+        # added
+        self._batched_op = True
+
+    @catch_exception_mapper_process
     def process(self, sample):
         # there is no video in this sample
+        sample = convert_dict_list_to_list_dict(samples=sample,
+                                                text_key=self.text_key)[0]
         if self.video_key not in sample or not sample[self.video_key]:
             return sample
 
@@ -140,4 +148,5 @@ class VideoResizeAspectRatioMapper(Mapper):
             loaded_video_keys[index] = resized_video_key
 
         sample[self.video_key] = loaded_video_keys
-        return sample
+        res_sample = convert_list_dict_to_dict_list([sample])
+        return res_sample

--- a/data_juicer/ops/mapper/video_resize_aspect_ratio_mapper.py
+++ b/data_juicer/ops/mapper/video_resize_aspect_ratio_mapper.py
@@ -7,9 +7,7 @@ from data_juicer.utils.file_utils import transfer_filename
 from data_juicer.utils.logger_utils import HiddenPrints
 from data_juicer.utils.mm_utils import load_video
 
-from ..base_op import (OPERATORS, Mapper, catch_exception_mapper_process,
-                       convert_dict_list_to_list_dict,
-                       convert_list_dict_to_dict_list)
+from ..base_op import OPERATORS, Mapper, catch_exception_mapper_process_single
 
 OP_NAME = 'video_resize_aspect_ratio_mapper'
 
@@ -100,15 +98,12 @@ class VideoResizeAspectRatioMapper(Mapper):
         self.min_ratio = Fraction(str(min_ratio).replace(':', '/'))
         self.max_ratio = Fraction(str(max_ratio).replace(':', '/'))
         self.strategy = strategy
-
-        # added
         self._batched_op = True
 
-    @catch_exception_mapper_process
+    # turned into batched processing and with catch
+    @catch_exception_mapper_process_single
     def process(self, sample):
         # there is no video in this sample
-        sample = convert_dict_list_to_list_dict(samples=sample,
-                                                text_key=self.text_key)[0]
         if self.video_key not in sample or not sample[self.video_key]:
             return sample
 
@@ -148,5 +143,4 @@ class VideoResizeAspectRatioMapper(Mapper):
             loaded_video_keys[index] = resized_video_key
 
         sample[self.video_key] = loaded_video_keys
-        res_sample = convert_list_dict_to_dict_list([sample])
-        return res_sample
+        return sample

--- a/data_juicer/ops/mapper/video_resize_resolution_mapper.py
+++ b/data_juicer/ops/mapper/video_resize_resolution_mapper.py
@@ -9,7 +9,7 @@ from data_juicer.utils.file_utils import transfer_filename
 from data_juicer.utils.logger_utils import HiddenPrints
 from data_juicer.utils.mm_utils import load_video
 
-from ..base_op import OPERATORS, Mapper
+from ..base_op import OPERATORS, Mapper, catch_exception_mapper_process_single
 from ..op_fusion import LOADED_VIDEOS
 
 OP_NAME = 'video_resize_resolution_mapper'
@@ -83,6 +83,7 @@ class VideoResizeResolutionMapper(Mapper):
         self.force_original_aspect_ratio = force_original_aspect_ratio
         self.force_divisible_by = force_divisible_by
 
+    @catch_exception_mapper_process_single
     def process(self, sample, context=False):
         # there is no video in this sample
         if self.video_key not in sample or not sample[self.video_key]:

--- a/data_juicer/ops/mapper/video_split_by_duration_mapper.py
+++ b/data_juicer/ops/mapper/video_split_by_duration_mapper.py
@@ -8,7 +8,7 @@ from data_juicer.utils.file_utils import (add_suffix_to_filename,
 from data_juicer.utils.mm_utils import (SpecialTokens, cut_video_by_seconds,
                                         get_video_duration, load_video)
 
-from ..base_op import OPERATORS, Mapper
+from ..base_op import OPERATORS, Mapper, catch_exception_mapper_process
 from ..op_fusion import LOADED_VIDEOS
 
 
@@ -132,6 +132,7 @@ class VideoSplitByDurationMapper(Mapper):
         split_sample[self.video_key] = split_video_keys
         return [split_sample]
 
+    @catch_exception_mapper_process
     def process(self, samples):
         # reconstruct samples from "dict of lists" to "list of dicts"
         reconstructed_samples = []

--- a/data_juicer/ops/mapper/video_split_by_key_frame_mapper.py
+++ b/data_juicer/ops/mapper/video_split_by_key_frame_mapper.py
@@ -6,7 +6,7 @@ from data_juicer.utils.file_utils import (add_suffix_to_filename,
 from data_juicer.utils.mm_utils import (SpecialTokens, cut_video_by_seconds,
                                         get_key_frame_seconds, load_video)
 
-from ..base_op import OPERATORS, Mapper
+from ..base_op import OPERATORS, Mapper, catch_exception_mapper_process
 from ..op_fusion import LOADED_VIDEOS
 
 
@@ -114,6 +114,7 @@ class VideoSplitByKeyFrameMapper(Mapper):
         split_sample[self.video_key] = split_video_keys
         return [split_sample]
 
+    @catch_exception_mapper_process
     def process(self, samples):
         # reconstruct samples from "dict of lists" to "list of dicts"
         reconstructed_samples = []

--- a/data_juicer/ops/mapper/video_split_by_scene_mapper.py
+++ b/data_juicer/ops/mapper/video_split_by_scene_mapper.py
@@ -9,7 +9,7 @@ from data_juicer.utils.file_utils import (add_suffix_to_filename,
                                           transfer_filename)
 from data_juicer.utils.mm_utils import SpecialTokens
 
-from ..base_op import OPERATORS, Mapper
+from ..base_op import OPERATORS, Mapper, catch_exception_mapper_process_single
 
 OP_NAME = 'video_split_by_scene_mapper'
 
@@ -81,6 +81,7 @@ class VideoSplitBySceneMapper(Mapper):
             for key in avaliable_kwargs if key in kwargs
         }
 
+    @catch_exception_mapper_process_single
     def process(self, sample, context=False):
         # there is no video in this sample
         if self.video_key not in sample or not sample[self.video_key]:

--- a/data_juicer/ops/mapper/video_tagging_from_audio_mapper.py
+++ b/data_juicer/ops/mapper/video_tagging_from_audio_mapper.py
@@ -5,7 +5,7 @@ from data_juicer.utils.constant import Fields
 from data_juicer.utils.mm_utils import extract_audio_from_video
 from data_juicer.utils.model_utils import get_model, prepare_model
 
-from ..base_op import OPERATORS, Mapper
+from ..base_op import OPERATORS, Mapper, catch_exception_mapper_process_single
 
 OP_NAME = 'video_tagging_from_audio_mapper'
 
@@ -40,6 +40,7 @@ class VideoTaggingFromAudioMapper(Mapper):
         self._model_sampling_rate = 16000
         self._no_audio_label = 'EMPTY'
 
+    @catch_exception_mapper_process_single
     def process(self, sample, rank=None):
         # check if it's generated already
         if Fields.video_audio_tags in sample:

--- a/data_juicer/ops/mapper/video_tagging_from_frames_mapper.py
+++ b/data_juicer/ops/mapper/video_tagging_from_frames_mapper.py
@@ -9,7 +9,7 @@ from data_juicer.utils.mm_utils import (extract_key_frames,
                                         load_data_with_context, load_video)
 from data_juicer.utils.model_utils import get_model, prepare_model
 
-from ..base_op import OPERATORS, Mapper
+from ..base_op import OPERATORS, Mapper, catch_exception_mapper_process_single
 from ..op_fusion import LOADED_VIDEOS
 
 OP_NAME = 'video_tagging_from_frames_mapper'
@@ -68,6 +68,7 @@ class VideoTaggingFromFramesMapper(Mapper):
         from ram import get_transform
         self.transform = get_transform(image_size=384)
 
+    @catch_exception_mapper_process_single
     def process(self, sample, rank=None, context=False):
         # check if it's generated already
         if Fields.video_frame_tags in sample:

--- a/data_juicer/ops/mapper/whitespace_normalization_mapper.py
+++ b/data_juicer/ops/mapper/whitespace_normalization_mapper.py
@@ -26,9 +26,8 @@ class WhitespaceNormalizationMapper(Mapper):
         super().__init__(*args, **kwargs)
 
     @catch_exception_mapper_process_single
-    def process(
-            self,
-            sample):  # remove whitespaces before and after the main content
+    def process(self, sample):
+        # remove whitespaces before and after the main content
         text = sample[self.text_key].strip()
 
         # replace all kinds of whitespaces with ' '

--- a/data_juicer/ops/mapper/whitespace_normalization_mapper.py
+++ b/data_juicer/ops/mapper/whitespace_normalization_mapper.py
@@ -2,7 +2,7 @@
 # https://github.com/bigscience-workshop/data-preparation
 # --------------------------------------------------------
 
-from ..base_op import OPERATORS, Mapper
+from ..base_op import OPERATORS, Mapper, catch_exception_mapper_process_single
 from ..common.special_characters import VARIOUS_WHITESPACES
 
 
@@ -25,8 +25,10 @@ class WhitespaceNormalizationMapper(Mapper):
         """
         super().__init__(*args, **kwargs)
 
-    def process(self, sample):
-        # remove whitespaces before and after the main content
+    @catch_exception_mapper_process_single
+    def process(
+            self,
+            sample):  # remove whitespaces before and after the main content
         text = sample[self.text_key].strip()
 
         # replace all kinds of whitespaces with ' '


### PR DESCRIPTION
The PR here is an example of rewriting sample error catching.

The current data-juicer abruptly stops the program when an error arises due to an issue with a specific sample, which requires a direct rerun, and no outputs are exported. As shown in the image:
![image](https://github.com/modelscope/data-juicer/assets/46197280/e3d931ae-6357-486e-9040-5349f338efda)

After modification, errors caused by a specific sample will not interrupt the program; instead, exception handling will take place. The subsequent steps will continue to run and export the final outputs. As shown in the image:
![image](https://github.com/modelscope/data-juicer/assets/46197280/85c5c569-3071-4617-b1b5-b5b37be61c7d)


FUTURE TODOs:

- [ ] Expand to filters
- [ ] Optimize batch efficiency
- [ ] Improve the transmission of error messages