### PR TITLE
fix vid_cap_from_frm_args None error

### DIFF
--- a/data_juicer/ops/mapper/video_captioning_from_summarizer_mapper.py
+++ b/data_juicer/ops/mapper/video_captioning_from_summarizer_mapper.py
@@ -123,7 +123,7 @@ class VideoCaptioningFromSummarizerMapper(Mapper):
         if vid_cap_from_vid_args is None:
             vid_cap_from_vid_args = {}
         if vid_cap_from_frm_args is None:
-            vid_tag_from_frm_args = {}
+            vid_cap_from_frm_args = {}
         if vid_tag_from_aud_args is None:
             vid_tag_from_aud_args = {}
         if vid_tag_from_frm_args is None:


### PR DESCRIPTION
when use "video_captioning_from_summarizer_mapper"  and set  "vid_cap_from_frm_args"  to "null", will produce bug. 