### PR TITLE
所有涉及到hf_model的算子，都加了一个trust_remote_code的参数并且传递给prepare_model函数

### DIFF
--- a/data_juicer/ops/filter/image_aesthetics_filter.py
+++ b/data_juicer/ops/filter/image_aesthetics_filter.py
@@ -33,6 +33,7 @@ class ImageAestheticsFilter(Filter):
 
     def __init__(self,
                  hf_scorer_model='',
+                 trust_remote_code=False,
                  min_score: ClosedUnitInterval = 0.5,
                  max_score: ClosedUnitInterval = 1.0,
                  any_or_all: str = 'any',
@@ -69,7 +70,8 @@ class ImageAestheticsFilter(Filter):
 
         self.model_key = prepare_model(
             model_type='simple_aesthetics',
-            pretrained_model_name_or_path=hf_scorer_model)
+            pretrained_model_name_or_path=hf_scorer_model,
+            trust_remote_code=trust_remote_code)
         # the original score predicted by laion-ai's scorer is within [0, 10]
         self.need_normalized_by_ten = ('shunk031/aesthetics-predictor'
                                        in hf_scorer_model)

--- a/data_juicer/ops/filter/image_nsfw_filter.py
+++ b/data_juicer/ops/filter/image_nsfw_filter.py
@@ -28,6 +28,7 @@ class ImageNSFWFilter(Filter):
 
     def __init__(self,
                  hf_nsfw_model='Falconsai/nsfw_image_detection',
+                 trust_remote_code=False,
                  score_threshold: ClosedUnitInterval = 0.5,
                  any_or_all: str = 'any',
                  *args,
@@ -54,7 +55,8 @@ class ImageNSFWFilter(Filter):
         self.any = (any_or_all == 'any')
         self.model_key = prepare_model(
             model_type='huggingface',
-            pretrained_model_name_or_path=hf_nsfw_model)
+            pretrained_model_name_or_path=hf_nsfw_model,
+            trust_remote_code=trust_remote_code)
 
     def compute_stats(self, sample, rank=None, context=False):
         # check if it's computed already

--- a/data_juicer/ops/filter/image_text_matching_filter.py
+++ b/data_juicer/ops/filter/image_text_matching_filter.py
@@ -31,6 +31,7 @@ class ImageTextMatchingFilter(Filter):
 
     def __init__(self,
                  hf_blip='Salesforce/blip-itm-base-coco',
+                 trust_remote_code=False,
                  min_score: ClosedUnitInterval = 0.003,
                  max_score: ClosedUnitInterval = 1.0,
                  horizontal_flip: bool = False,
@@ -71,7 +72,8 @@ class ImageTextMatchingFilter(Filter):
                              f'Can only be one of ["any", "all"].')
         self.any = (any_or_all == 'any')
         self.model_key = prepare_model(model_type='huggingface',
-                                       pretrained_model_name_or_path=hf_blip)
+                                       pretrained_model_name_or_path=hf_blip,
+                                       trust_remote_code=trust_remote_code)
         self.reduce_mode = reduce_mode
         self.horizontal_flip = horizontal_flip
         self.vertical_flip = vertical_flip

--- a/data_juicer/ops/filter/image_text_similarity_filter.py
+++ b/data_juicer/ops/filter/image_text_similarity_filter.py
@@ -32,6 +32,7 @@ class ImageTextSimilarityFilter(Filter):
 
     def __init__(self,
                  hf_clip='openai/clip-vit-base-patch32',
+                 trust_remote_code=False,
                  min_score: ClosedUnitInterval = 0.1,
                  max_score: ClosedUnitInterval = 1.0,
                  horizontal_flip: bool = False,
@@ -72,7 +73,8 @@ class ImageTextSimilarityFilter(Filter):
                              f'Can only be one of ["any", "all"].')
         self.any = (any_or_all == 'any')
         self.model_key = prepare_model(model_type='huggingface',
-                                       pretrained_model_name_or_path=hf_clip)
+                                       pretrained_model_name_or_path=hf_clip,
+                                       trust_remote_code=trust_remote_code)
         self.reduce_mode = reduce_mode
         self.horizontal_flip = horizontal_flip
         self.vertical_flip = vertical_flip

--- a/data_juicer/ops/filter/image_watermark_filter.py
+++ b/data_juicer/ops/filter/image_watermark_filter.py
@@ -31,6 +31,7 @@ class ImageWatermarkFilter(Filter):
 
     def __init__(self,
                  hf_watermark_model='amrul-hzz/watermark_detector',
+                 trust_remote_code=False,
                  prob_threshold: ClosedUnitInterval = 0.8,
                  any_or_all: str = 'any',
                  *args,
@@ -58,7 +59,8 @@ class ImageWatermarkFilter(Filter):
         self.any = (any_or_all == 'any')
         self.model_key = prepare_model(
             model_type='huggingface',
-            pretrained_model_name_or_path=hf_watermark_model)
+            pretrained_model_name_or_path=hf_watermark_model,
+            trust_remote_code=trust_remote_code)
 
     def compute_stats(self, sample, rank=None, context=False):
         # check if it's computed already

--- a/data_juicer/ops/filter/phrase_grounding_recall_filter.py
+++ b/data_juicer/ops/filter/phrase_grounding_recall_filter.py
@@ -78,6 +78,7 @@ class PhraseGroundingRecallFilter(Filter):
 
     def __init__(self,
                  hf_owlvit='google/owlvit-base-patch32',
+                 trust_remote_code=False,
                  min_recall: ClosedUnitInterval = 0.1,
                  max_recall: ClosedUnitInterval = 1.0,
                  horizontal_flip: bool = False,
@@ -132,7 +133,8 @@ class PhraseGroundingRecallFilter(Filter):
                              f'Can only be one of ["any", "all"].')
         self.any = (any_or_all == 'any')
         self.model_key = prepare_model(model_type='huggingface',
-                                       pretrained_model_name_or_path=hf_owlvit)
+                                       pretrained_model_name_or_path=hf_owlvit,
+                                       trust_remote_code=trust_remote_code)
         self.reduce_mode = reduce_mode
         self.horizontal_flip = horizontal_flip
         self.vertical_flip = vertical_flip

--- a/data_juicer/ops/filter/video_aesthetics_filter.py
+++ b/data_juicer/ops/filter/video_aesthetics_filter.py
@@ -37,6 +37,7 @@ class VideoAestheticsFilter(Filter):
 
     def __init__(self,
                  hf_scorer_model='',
+                 trust_remote_code=False,
                  min_score: ClosedUnitInterval = 0.4,
                  max_score: ClosedUnitInterval = 1.0,
                  frame_sampling_method: str = 'uniform',
@@ -105,7 +106,8 @@ class VideoAestheticsFilter(Filter):
 
         self.model_key = prepare_model(
             model_type='simple_aesthetics',
-            pretrained_model_name_or_path=hf_scorer_model)
+            pretrained_model_name_or_path=hf_scorer_model,
+            trust_remote_code=trust_remote_code)
         # the original score predicted by laion-ai's scorer is within [0, 10]
         self.need_normalized_by_ten = ('shunk031/aesthetics-predictor'
                                        in hf_scorer_model)

--- a/data_juicer/ops/filter/video_frames_text_similarity_filter.py
+++ b/data_juicer/ops/filter/video_frames_text_similarity_filter.py
@@ -36,6 +36,7 @@ class VideoFramesTextSimilarityFilter(Filter):
 
     def __init__(self,
                  hf_clip='openai/clip-vit-base-patch32',
+                 trust_remote_code=False,
                  min_score: ClosedUnitInterval = 0.1,
                  max_score: ClosedUnitInterval = 1.0,
                  frame_sampling_method: str = 'all_keyframes',
@@ -98,7 +99,8 @@ class VideoFramesTextSimilarityFilter(Filter):
                              f'Can only be one of ["any", "all"].')
         self.any = (any_or_all == 'any')
         self.model_key = prepare_model(model_type='huggingface',
-                                       pretrained_model_name_or_path=hf_clip)
+                                       pretrained_model_name_or_path=hf_clip,
+                                       trust_remote_code=trust_remote_code)
         self.reduce_mode = reduce_mode
         self.horizontal_flip = horizontal_flip
         self.vertical_flip = vertical_flip

--- a/data_juicer/ops/filter/video_nsfw_filter.py
+++ b/data_juicer/ops/filter/video_nsfw_filter.py
@@ -32,6 +32,7 @@ class VideoNSFWFilter(Filter):
 
     def __init__(self,
                  hf_nsfw_model='Falconsai/nsfw_image_detection',
+                 trust_remote_code=False,
                  score_threshold: ClosedUnitInterval = 0.5,
                  frame_sampling_method: str = 'all_keyframes',
                  frame_num: PositiveInt = 3,
@@ -86,7 +87,8 @@ class VideoNSFWFilter(Filter):
         self.any = (any_or_all == 'any')
         self.model_key = prepare_model(
             model_type='huggingface',
-            pretrained_model_name_or_path=hf_nsfw_model)
+            pretrained_model_name_or_path=hf_nsfw_model,
+            trust_remote_code=trust_remote_code)
         self.reduce_mode = reduce_mode
         self.frame_sampling_method = frame_sampling_method
         self.frame_num = frame_num

--- a/data_juicer/ops/filter/video_watermark_filter.py
+++ b/data_juicer/ops/filter/video_watermark_filter.py
@@ -35,6 +35,7 @@ class VideoWatermarkFilter(Filter):
 
     def __init__(self,
                  hf_watermark_model='amrul-hzz/watermark_detector',
+                 trust_remote_code=False,
                  prob_threshold: ClosedUnitInterval = 0.8,
                  frame_sampling_method: str = 'all_keyframes',
                  frame_num: PositiveInt = 3,
@@ -90,7 +91,8 @@ class VideoWatermarkFilter(Filter):
         self.any = (any_or_all == 'any')
         self.model_key = prepare_model(
             model_type='huggingface',
-            pretrained_model_name_or_path=hf_watermark_model)
+            pretrained_model_name_or_path=hf_watermark_model,
+            trust_remote_code=trust_remote_code)
         self.reduce_mode = reduce_mode
         self.frame_sampling_method = frame_sampling_method
         self.frame_num = frame_num

--- a/data_juicer/ops/mapper/extract_qa_mapper.py
+++ b/data_juicer/ops/mapper/extract_qa_mapper.py
@@ -27,6 +27,7 @@ class ExtractQAMapper(Mapper):
 
     def __init__(self,
                  hf_model: str = 'alibaba-pai/pai-qwen1_5-7b-doc2qa',
+                 trust_remote_code=False,
                  pattern: str = None,
                  qa_format: str = 'chatml',
                  *args,
@@ -62,7 +63,8 @@ class ExtractQAMapper(Mapper):
 
         self.qa_format = qa_format
         self.model_key = prepare_model(model_type='huggingface',
-                                       pretrained_model_name_or_path=hf_model)
+                                       pretrained_model_name_or_path=hf_model,
+                                       trust_remote_code=trust_remote_code)
 
     def _extract_qa(self, output):
         """Extract qestion and answer pair from model output response."""

--- a/data_juicer/ops/mapper/image_captioning_mapper.py
+++ b/data_juicer/ops/mapper/image_captioning_mapper.py
@@ -39,6 +39,7 @@ class ImageCaptioningMapper(Mapper):
 
     def __init__(self,
                  hf_img2seq='Salesforce/blip2-opt-2.7b',
+                 trust_remote_code=False,
                  caption_num: PositiveInt = 1,
                  keep_candidate_mode: str = 'random_any',
                  keep_original_sample: bool = True,
@@ -97,7 +98,7 @@ class ImageCaptioningMapper(Mapper):
                 f'["random_any", "similar_one_simhash", "all"].')
 
         self.model_key = prepare_model(
-            model_type='huggingface', pretrained_model_name_or_path=hf_img2seq)
+            model_type='huggingface', pretrained_model_name_or_path=hf_img2seq, trust_remote_code=trust_remote_code)
         self.caption_num = caption_num
         self.keep_candidate_mode = keep_candidate_mode
         self.keep_original_sample = keep_original_sample

--- a/data_juicer/ops/mapper/image_captioning_mapper.py
+++ b/data_juicer/ops/mapper/image_captioning_mapper.py
@@ -98,7 +98,9 @@ class ImageCaptioningMapper(Mapper):
                 f'["random_any", "similar_one_simhash", "all"].')
 
         self.model_key = prepare_model(
-            model_type='huggingface', pretrained_model_name_or_path=hf_img2seq, trust_remote_code=trust_remote_code)
+            model_type='huggingface',
+            pretrained_model_name_or_path=hf_img2seq,
+            trust_remote_code=trust_remote_code)
         self.caption_num = caption_num
         self.keep_candidate_mode = keep_candidate_mode
         self.keep_original_sample = keep_original_sample

--- a/data_juicer/ops/mapper/image_diffusion_mapper.py
+++ b/data_juicer/ops/mapper/image_diffusion_mapper.py
@@ -38,6 +38,7 @@ class ImageDiffusionMapper(Mapper):
 
     def __init__(self,
                  hf_diffusion: str = 'CompVis/stable-diffusion-v1-4',
+                 trust_remote_code=False,
                  torch_dtype: str = 'fp32',
                  revision: str = 'main',
                  strength: float = 0.8,
@@ -117,7 +118,8 @@ class ImageDiffusionMapper(Mapper):
             pretrained_model_name_or_path=hf_diffusion,
             diffusion_type='image2image',
             torch_dtype=torch_dtype,
-            revision=revision)
+            revision=revision,
+            trust_remote_code=trust_remote_code)
 
     def _real_guidance(self, caption: str, image: Image.Image, rank=None):
 

--- a/data_juicer/ops/mapper/video_captioning_from_frames_mapper.py
+++ b/data_juicer/ops/mapper/video_captioning_from_frames_mapper.py
@@ -47,6 +47,7 @@ class VideoCaptioningFromFramesMapper(Mapper):
     def __init__(
         self,
         hf_img2seq='Salesforce/blip2-opt-2.7b',
+        trust_remote_code=False,
         caption_num: PositiveInt = 1,
         keep_candidate_mode: str = 'random_any',
         keep_original_sample: bool = True,
@@ -158,6 +159,7 @@ class VideoCaptioningFromFramesMapper(Mapper):
         self.model_key = prepare_model(
             model_type='huggingface',
             pretrained_model_name_or_path=hf_img2seq,
+            trust_remote_code=trust_remote_code
         )
 
     def _process_single_sample(self, ori_sample, rank=None, context=False):

--- a/data_juicer/ops/mapper/video_captioning_from_summarizer_mapper.py
+++ b/data_juicer/ops/mapper/video_captioning_from_summarizer_mapper.py
@@ -54,6 +54,7 @@ class VideoCaptioningFromSummarizerMapper(Mapper):
 
     def __init__(self,
                  hf_summarizer: str = None,
+                 trust_remote_code=False,
                  consider_video_caption_from_video: bool = True,
                  consider_video_caption_from_audio: bool = True,
                  consider_video_caption_from_frames: bool = True,
@@ -119,6 +120,7 @@ class VideoCaptioningFromSummarizerMapper(Mapper):
         self.model_key = prepare_model(
             model_type='huggingface',
             pretrained_model_name_or_path=self._hf_summarizer,
+            trust_remote_code=trust_remote_code
         )
 
         # prepare input texts ops

--- a/data_juicer/ops/mapper/video_captioning_from_summarizer_mapper.py
+++ b/data_juicer/ops/mapper/video_captioning_from_summarizer_mapper.py
@@ -120,8 +120,7 @@ class VideoCaptioningFromSummarizerMapper(Mapper):
         self.model_key = prepare_model(
             model_type='huggingface',
             pretrained_model_name_or_path=self._hf_summarizer,
-            trust_remote_code=trust_remote_code
-        )
+            trust_remote_code=trust_remote_code)
 
         # prepare input texts ops
         if vid_cap_from_vid_args is None:

--- a/data_juicer/ops/mapper/video_captioning_from_video_mapper.py
+++ b/data_juicer/ops/mapper/video_captioning_from_video_mapper.py
@@ -46,6 +46,7 @@ class VideoCaptioningFromVideoMapper(Mapper):
     def __init__(
         self,
         hf_video_blip='kpyu/video-blip-opt-2.7b-ego4d',
+        trust_remote_code=False,
         caption_num: PositiveInt = 1,
         keep_candidate_mode: str = 'random_any',
         keep_original_sample: bool = True,
@@ -158,6 +159,7 @@ class VideoCaptioningFromVideoMapper(Mapper):
         self.model_key = prepare_model(
             model_type='video_blip',
             pretrained_model_name_or_path=hf_video_blip,
+            trust_remote_code=trust_remote_code
         )
 
     def _process_single_sample(self, ori_sample, rank=None, context=False):

--- a/data_juicer/ops/mapper/video_tagging_from_audio_mapper.py
+++ b/data_juicer/ops/mapper/video_tagging_from_audio_mapper.py
@@ -28,6 +28,7 @@ class VideoTaggingFromAudioMapper(Mapper):
 
     def __init__(self,
                  hf_ast='MIT/ast-finetuned-audioset-10-10-0.4593',
+                 trust_remote_code=False,
                  *args,
                  **kwargs):
         """
@@ -38,7 +39,8 @@ class VideoTaggingFromAudioMapper(Mapper):
         """
         super().__init__(*args, **kwargs)
         self.model_key = prepare_model(model_type='huggingface',
-                                       pretrained_model_name_or_path=hf_ast)
+                                       pretrained_model_name_or_path=hf_ast,
+                                       trust_remote_code=trust_remote_code)
         self._model_sampling_rate = 16000
         self._no_audio_label = 'EMPTY'
 


### PR DESCRIPTION
在使用一个算子的时候，下载最新的huggingface模型时，提示需要将trust_remote_code设置为True，对于部分模型，这个参数必须这样设置才能下载，但是data-juicer的所有算子都没有支持这一参数。
在此背景下，经过查看代码，发现prepare_model函数可以将算子的参数传递给prepare_huggingface_model函数，但是prepare_huggingface_model的trust_remote_code参数默认为False，于是将所有需要使用huggingface模型的算子都增加了对trust_remote_code参数的接口，并且默认设置为False，并传递给prepare_model，只需要修改配置文件，在其中增加trust_remote_code参数便可以进行修改，无需改动其他部分。