### PR TITLE
Regress model preloading

### DIFF
--- a/data_juicer/utils/model_utils.py
+++ b/data_juicer/utils/model_utils.py
@@ -621,6 +621,8 @@ def prepare_model(model_type, **model_kwargs):
     global MODEL_ZOO
     model_func = MODEL_FUNCTION_MAPPING[model_type]
     model_key = partial(model_func, **model_kwargs)
+    # always instantiate once for possible caching
+    model_key()
     return model_key
 
 


### PR DESCRIPTION
Always instantiate the model once in the main process for possible downloading and caching.

