### PR TITLE
[Ready] support API retry

### DIFF
--- a/data_juicer/ops/mapper/calibrate_qa_mapper.py
+++ b/data_juicer/ops/mapper/calibrate_qa_mapper.py
@@ -31,7 +31,6 @@ class CalibrateQAMapper(Mapper):
                  api_model: str = 'gpt-4o',
                  *,
                  api_url: Optional[str] = None,
-                 api_key: Optional[str] = None,
                  response_path: Optional[str] = None,
                  system_prompt: Optional[str] = None,
                  input_template: Optional[str] = None,
@@ -45,8 +44,7 @@ class CalibrateQAMapper(Mapper):
         Initialization method.
 
         :param api_model: API model name.
-        :param api_url: API URL. Defaults to DJ_API_URL environment variable.
-        :param api_key: API key. Defaults to DJ_API_KEY environment variable.
+        :param api_url: URL endpoint for the API.
         :param response_path: Path to extract content from the API response.
             Defaults to 'choices.0.message.content'.
         :param system_prompt: System prompt for the calibration task.
@@ -54,7 +52,7 @@ class CalibrateQAMapper(Mapper):
         :param reference_template: Template for formatting the reference text.
         :param qa_pair_template: Template for formatting question-answer pairs.
         :param output_pattern: Regular expression for parsing model output.
-        :param model_params: Parameters for initializing the model.
+        :param model_params: Parameters for initializing the API model.
         :param sampling_params: Extra parameters passed to the API call.
         :param kwargs: Extra keyword arguments.
         """
@@ -67,13 +65,12 @@ class CalibrateQAMapper(Mapper):
         self.qa_pair_template = qa_pair_template or \
             self.DEFAULT_QA_PAIR_TEMPLATE
         self.output_pattern = output_pattern or self.DEFAULT_OUTPUT_PATTERN
-
-        self.model_params = model_params or {}
         self.sampling_params = sampling_params or {}
+
+        model_params = model_params or {}
         self.model_key = prepare_model(model_type='api',
-                                       api_model=api_model,
-                                       api_url=api_url,
-                                       api_key=api_key,
+                                       model=api_model,
+                                       url=api_url,
                                        response_path=response_path,
                                        **model_params)
 

--- a/tests/ops/mapper/test_calibrate_qa_mapper.py
+++ b/tests/ops/mapper/test_calibrate_qa_mapper.py
@@ -1,5 +1,3 @@
-import io
-import logging
 import os
 import unittest
 from unittest.mock import Mock, patch
@@ -77,7 +75,7 @@ class CalibrateQAMapperTest(DataJuicerTestCaseBase):
         op = CalibrateQAMapper(api_model='qwen2.5-72b-instruct')
         self._run_op(op)
 
-    def test_specified(self):
+    def test_args(self):
         op = CalibrateQAMapper(
             api_model='qwen2.5-72b-instruct',
             api_url=
@@ -97,21 +95,11 @@ class CalibrateQAMapperTest(DataJuicerTestCaseBase):
             response=mock_response)
         mock_send.return_value = mock_response
 
-        log_stream = io.StringIO()
-        stream_handler = logging.StreamHandler(log_stream)
-        stream_handler.setLevel(logging.DEBUG)
-        logger = logging.getLogger()
-        logger.addHandler(stream_handler)
-        try:
+        with self.assertLogs() as cm:
             op = CalibrateQAMapper(api_model='test',
                                    model_params={'max_retries': 3})
             op.process({'text': '', 'query': '', 'response': ''})
-            log_contents = log_stream.getvalue()
-            self.assertIn('3 retries left', log_contents)
-        finally:
-            logger.removeHandler(stream_handler)
-            log_stream.close()
-
+        self.assertIn('3 retries left', '\n'.join(cm.output))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/ops/mapper/test_calibrate_qa_mapper.py
+++ b/tests/ops/mapper/test_calibrate_qa_mapper.py
@@ -15,8 +15,6 @@ from data_juicer.utils.unittest_utils import (SKIPPED_TESTS,
 @SKIPPED_TESTS.register_module()
 class CalibrateQAMapperTest(DataJuicerTestCaseBase):
 
-    os.environ['OPENAI_LOG'] = 'debug'
-
     def _run_op(self, op):
         reference = """# 角色语言风格
 1. 下面是李莲花的问答样例，你必须贴合他的语言风格：
@@ -95,7 +93,7 @@ class CalibrateQAMapperTest(DataJuicerTestCaseBase):
             response=mock_response)
         mock_send.return_value = mock_response
 
-        with self.assertLogs() as cm:
+        with self.assertLogs(level='DEBUG') as cm:
             op = CalibrateQAMapper(api_model='test',
                                    model_params={'max_retries': 3})
             op.process({'text': '', 'query': '', 'response': ''})


### PR DESCRIPTION
- Use OpenAI's `client.post` to be compatibility with OpenAI, Dashscope, etc., while allowing for customizable API endpoints.
- All parameters supported by OpenAI are accepted, such as `timeout`, `max_retries`, etc., which can be passed through the `model_params` parameter of the operator.
- Add mocked API unit tests.