### PR TITLE
op/command_mapper

### DIFF
--- a/data_juicer/ops/mapper/__init__.py
+++ b/data_juicer/ops/mapper/__init__.py
@@ -8,6 +8,7 @@ from .clean_email_mapper import CleanEmailMapper
 from .clean_html_mapper import CleanHtmlMapper
 from .clean_ip_mapper import CleanIpMapper
 from .clean_links_mapper import CleanLinksMapper
+from .command_mapper import CommandMapper
 from .expand_macro_mapper import ExpandMacroMapper
 from .fix_unicode_mapper import FixUnicodeMapper
 from .generate_qa_from_examples_mapper import GenerateQAFromExamplesMapper
@@ -59,12 +60,12 @@ __all__ = [
     'AudioFFmpegWrappedMapper', 'CalibrateQAMapper', 'CalibrateQueryMapper',
     'CalibrateResponseMapper', 'ChineseConvertMapper', 'CleanCopyrightMapper',
     'CleanEmailMapper', 'CleanHtmlMapper', 'CleanIpMapper', 'CleanLinksMapper',
-    'ExpandMacroMapper', 'FixUnicodeMapper', 'GenerateQAFromExamplesMapper',
-    'GenerateQAFromTextMapper', 'ImageBlurMapper',
-    'ImageCaptioningFromGPT4VMapper', 'ImageCaptioningMapper',
-    'ImageDiffusionMapper', 'ImageFaceBlurMapper', 'ImageTaggingMapper',
-    'NlpaugEnMapper', 'NlpcdaZhMapper', 'OptimizeQAMapper',
-    'OptimizeQueryMapper', 'OptimizeResponseMapper',
+    'CommandMapper', 'ExpandMacroMapper', 'FixUnicodeMapper',
+    'GenerateQAFromExamplesMapper', 'GenerateQAFromTextMapper',
+    'ImageBlurMapper', 'ImageCaptioningFromGPT4VMapper',
+    'ImageCaptioningMapper', 'ImageDiffusionMapper', 'ImageFaceBlurMapper',
+    'ImageTaggingMapper', 'NlpaugEnMapper', 'NlpcdaZhMapper',
+    'OptimizeQAMapper', 'OptimizeQueryMapper', 'OptimizeResponseMapper',
     'PunctuationNormalizationMapper', 'RemoveBibliographyMapper',
     'RemoveCommentsMapper', 'RemoveHeaderMapper', 'RemoveLongWordsMapper',
     'RemoveNonChineseCharacterlMapper', 'RemoveRepeatSentencesMapper',

--- a/data_juicer/ops/mapper/command_mapper.py
+++ b/data_juicer/ops/mapper/command_mapper.py
@@ -1,0 +1,57 @@
+import json
+import subprocess
+
+from data_juicer.utils.lazy_loader import LazyLoader
+
+from ..base_op import OPERATORS, Mapper
+
+json_repair = LazyLoader('json_repair', 'json_repair')
+
+OP_NAME = 'command_mapper'
+
+
+@OPERATORS.register_module(OP_NAME)
+class CommandMapper(Mapper):
+    """Mapper to execute inline code or an external script file.
+
+    This class allows executing Python or shell scripts, taking input in
+    JSON format and expecting JSON output.
+    """
+
+    def __init__(self, command: str = '', repair=True, **kwargs):
+        """
+        Initialization method.
+
+        :param command: The command to execute. If an empty string is given,
+            the input sample is return unchanged.
+        :param repair: If True, uses `json_repair` to load JSON; otherwise,
+            uses the standard `json` library.
+        :param kwargs: Additional keyword arguments.
+        """
+        super().__init__(**kwargs)
+
+        self.command = command
+        self.repair = repair
+        if self.repair:
+            self.json_loads = json_repair.loads
+        else:
+            self.json_loads = json.loads
+
+    def process_single(self, sample):
+        if not self.command:
+            return sample
+
+        # Serialize the input data to JSON
+        input_data = json.dumps(sample)
+
+        # Execute the command, capturing both stdout and stderr
+        result = subprocess.run(self.command,
+                                input=input_data,
+                                capture_output=True,
+                                text=True,
+                                shell=True)
+
+        if result.returncode != 0:
+            raise Exception(f'Execution failed: {result.stderr}')
+
+        return self.json_loads(result.stdout)  # Return the parsed JSON output

--- a/data_juicer/utils/auto_install_mapping.py
+++ b/data_juicer/utils/auto_install_mapping.py
@@ -8,6 +8,7 @@ MODULE_TO_PKGS = {
     'ram': ['ram@git+https://github.com/xinyu1205/recognize-anything.git'],
     'scenedetect': ['scenedetect[opencv]'],
     'simhash': ['simhash-pybind'],
+    'json_repair': ['json-repair'],
 }
 
 # Packages to corresponding ops that require them
@@ -104,5 +105,6 @@ PKG_TO_OPS = {
         'optimize_qa_mapper',
     ],
     'rouge': ['generate_qa_from_examples_mapper'],
-    'ram': ['image_tagging_mapper', 'video_tagging_from_frames_mapper']
+    'ram': ['image_tagging_mapper', 'video_tagging_from_frames_mapper'],
+    'json-repair': ['command_mapper'],
 }

--- a/environments/science_requires.txt
+++ b/environments/science_requires.txt
@@ -26,3 +26,4 @@ ffmpeg-python
 opencv-python
 vllm>=0.1.3
 rouge
+json-repair

--- a/tests/ops/mapper/test_command_mapper.py
+++ b/tests/ops/mapper/test_command_mapper.py
@@ -52,6 +52,23 @@ class TestCommandMapper(DataJuicerTestCaseBase):
             op.process_single(sample)
         self.assertTrue('Execution failed:' in str(context.exception))
 
+    def test_python_command_with_input(self):
+        # Test executing a simple Python command that reads input and returns JSON.
+        python_command = 'python3 -c "import sys, json; ' \
+                         'input_data = sys.stdin.read(); ' \
+                         'data = json.loads(input_data); ' \
+                         'data[\'age\'] += 1; ' \
+                         'print(json.dumps(data))"'
+        op = CommandMapper(command=python_command)
+
+        # Create a sample input JSON for testing.
+        input_sample = {'name': 'Bob', 'age': 25}
+
+        # Process the input. The CommandMapper should read this input.
+        result = op.process_single(input_sample)
+        expected = {'name': 'Bob', 'age': 26}  # Expecting age to be incremented by 1.
+
+        self.assertEqual(result, expected)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/ops/mapper/test_command_mapper.py
+++ b/tests/ops/mapper/test_command_mapper.py
@@ -1,0 +1,57 @@
+import json
+import unittest
+
+from data_juicer.ops.mapper.command_mapper import CommandMapper
+from data_juicer.utils.unittest_utils import DataJuicerTestCaseBase
+
+
+class TestCommandMapper(DataJuicerTestCaseBase):
+
+    def test_execute_command(self):
+        # Test that the command executes successfully and returns
+        # the correct JSON output.
+        sample = {}
+        op = CommandMapper(command='echo \'{"name": "Alice", "age": 30}\'',
+                           repair=False)
+        result = op.process_single(sample)
+        expected = {'name': 'Alice', 'age': 30}
+        self.assertEqual(result, expected)
+
+    def test_empty_command(self):
+        # Test that an empty command returns the original input sample.
+        op = CommandMapper(command='')
+        sample = {'key': 'value'}
+        result = op.process_single(sample)
+        self.assertEqual(result, sample)
+
+    def test_json_parsing_error_no_repair(self):
+        # Test that a JSON parsing error is raised for invalid JSON output
+        # with repair=False.
+        faulty_command = 'echo \'{"name": "Alice", "age": 30\''
+        op_no_repair = CommandMapper(command=faulty_command, repair=False)
+        sample = {}
+        with self.assertRaises(json.JSONDecodeError):
+            op_no_repair.process_single(sample)
+
+    def test_json_parsing_error_with_repair(self):
+        # Test that the command output can be repaired and
+        # correctly parsed when repair=True.
+        faulty_command = 'echo \'{"name": "Alice", "age": 30\''
+        op_with_repair = CommandMapper(command=faulty_command, repair=True)
+        sample = {}
+        result = op_with_repair.process_single(sample)
+        expected = {'name': 'Alice', 'age': 30}
+        self.assertEqual(result, expected)
+
+    def test_command_execution_failure(self):
+        # Test that an exception is raised when the command execution fails.
+        faulty_command = 'ls non_existent_file'
+        op = CommandMapper(command=faulty_command)
+        sample = {}
+        with self.assertRaises(Exception) as context:
+            op.process_single(sample)
+        self.assertTrue('Execution failed:' in str(context.exception))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Added the prototype implementation of `CommandMapper`, which corresponds to the `ScriptOP` raised in issue #412. The following issues need discussion:

- Avoid creating subclasses like `PythonCodesOperator` or `BashCodesOperator`, as this hinders extensibility. Consider that if users want to support more shell types like `zsh`, or integrate with other programming languages or third-party tools, they would have to add new classes at the code level, which is cumbersome and unnecessary. With a single `CommandMapper`, we can maximize support for arbitrary extensions without modifying the source code.

- Operator naming. Currently, the operator is implemented as a mapper; therefore, the `Mapper` suffix is used instead of the original `ScriptOP`. Other candidate names include `ScriptMapper`, `CodeMapper`, `ExternalXXXMapper`, etc. I have opted for `CommandMapper` because it is not limited to just code or scripts; it can actually execute any command, such as pre-compiled binary files.

Everyone is welcome to provide feedback on the above issues, and I will add relevant documentation after reaching a consensus.