### PR TITLE
fix batch bug

### DIFF
--- a/data_juicer/core/data.py
+++ b/data_juicer/core/data.py
@@ -225,7 +225,7 @@ class NestedDataset(Dataset, DJDataset):
                                                  monitor_dir)
         return dataset
 
-    def update_common_args(self, args, kargs):
+    def update_args(self, args, kargs, is_filter=False):
         if args:
             args = list(args)
             # the first positional para is function
@@ -260,8 +260,8 @@ class NestedDataset(Dataset, DJDataset):
             else:
                 kargs['batched'] = False
 
-            # rank is required for cuda model loading
-            if callable(
+            # rank is required for cuda model loading for map
+            if not is_filter and callable(
                     getattr(called_func.__self__,
                             'use_cuda')) and called_func.__self__.use_cuda():
                 kargs['with_rank'] = True
@@ -276,7 +276,7 @@ class NestedDataset(Dataset, DJDataset):
         """Override the map func, which is called by most common operations,
         such that the processed samples can be accessed by nested manner."""
 
-        args, kargs = self.update_common_args(args, kargs)
+        args, kargs = self.update_args(args, kargs)
 
         if cache_utils.CACHE_COMPRESS:
             decompress(self, kargs['new_fingerprint'],
@@ -296,7 +296,7 @@ class NestedDataset(Dataset, DJDataset):
     def filter(self, *args, **kargs):
         """Override the filter func, which is called by most common operations,
         such that the processed samples can be accessed by nested manner."""
-        args, kargs = self.update_common_args(args, kargs)
+        args, kargs = self.update_args(args, kargs, is_filter=True)
 
         # For filter, it involves a map and a filter operations, so the final
         # cache files includes two sets with different fingerprint (before and

--- a/data_juicer/core/data.py
+++ b/data_juicer/core/data.py
@@ -225,9 +225,7 @@ class NestedDataset(Dataset, DJDataset):
                                                  monitor_dir)
         return dataset
 
-    def map(self, *args, **kargs):
-        """Override the map func, which is called by most common operations,
-        such that the processed samples can be accessed by nested manner."""
+    def update_common_args(self, args, kargs):
         if args:
             args = list(args)
             # the first positional para is function
@@ -253,10 +251,12 @@ class NestedDataset(Dataset, DJDataset):
             # batched is required for fault-tolerant or batched OP
             if callable(getattr(
                     called_func.__self__,
-                    'is_batched_op')) and called_func.__self__.is_batched_op(
-                    ) or not getattr(called_func.__self__, 'turbo', False):
+                    'is_batched_op')) and called_func.__self__.is_batched_op():
                 kargs['batched'] = True
                 kargs['batch_size'] = kargs.pop('batch_size', 1)
+            elif not getattr(called_func.__self__, 'turbo', False):
+                kargs['batched'] = True
+                kargs['batch_size'] = 1
             else:
                 kargs['batched'] = False
 
@@ -269,6 +269,14 @@ class NestedDataset(Dataset, DJDataset):
         if 'new_fingerprint' not in kargs or kargs['new_fingerprint'] is None:
             new_fingerprint = generate_fingerprint(self, *args, **kargs)
             kargs['new_fingerprint'] = new_fingerprint
+
+        return args, kargs
+
+    def map(self, *args, **kargs):
+        """Override the map func, which is called by most common operations,
+        such that the processed samples can be accessed by nested manner."""
+
+        args, kargs = self.update_common_args(args, kargs)
 
         if cache_utils.CACHE_COMPRESS:
             decompress(self, kargs['new_fingerprint'],
@@ -288,38 +296,7 @@ class NestedDataset(Dataset, DJDataset):
     def filter(self, *args, **kargs):
         """Override the filter func, which is called by most common operations,
         such that the processed samples can be accessed by nested manner."""
-        if args:
-            args = list(args)
-            # the first positional para is function
-            if args[0] is None:
-                args[0] = lambda x: nested_obj_factory(x)
-            else:
-                args[0] = wrap_func_with_nested_access(args[0])
-            called_func = args[0]
-        else:
-            if 'function' not in kargs or kargs['function'] is None:
-                kargs['function'] = lambda x: nested_obj_factory(x)
-            else:
-                kargs['function'] = wrap_func_with_nested_access(
-                    kargs['function'])
-            called_func = kargs['function']
-
-        # For wrapped function, try to get its unwrapped (bound) method
-        while not inspect.ismethod(called_func) and hasattr(
-                called_func, '__wrapped__'):
-            called_func = called_func.__wrapped__
-
-        # Batched is always required for fault tolerance
-        if inspect.ismethod(called_func):
-            if callable(getattr(
-                    called_func.__self__,
-                    'is_batched_op')) and called_func.__self__.is_batched_op():
-                kargs['batched'] = True
-                kargs['batch_size'] = kargs.pop('batch_size', 1)
-
-        if 'new_fingerprint' not in kargs or kargs['new_fingerprint'] is None:
-            new_fingerprint = generate_fingerprint(self, *args, **kargs)
-            kargs['new_fingerprint'] = new_fingerprint
+        args, kargs = self.update_common_args(args, kargs)
 
         # For filter, it involves a map and a filter operations, so the final
         # cache files includes two sets with different fingerprint (before and

--- a/environments/minimal_requires.txt
+++ b/environments/minimal_requires.txt
@@ -2,7 +2,7 @@ datasets>=2.19.0
 fsspec==2023.5.0
 pandas
 numpy
-av
+av==13.1.0
 soundfile
 librosa>=0.10
 loguru


### PR DESCRIPTION
1. 修改Turbo和batch操作的判断逻辑
- Turbo加速逻辑：对batch算子不起作用，非batch算子时turbo等于True不会打batch，速度快，等于false时打成batch size等于1的batch sample，速度慢。
- 原先逻辑turbo等于false时，非batch算子的batch size可能不等于1，导致sample丢失。

2. 将filter和map对参数相同的操作挪到一个函数里，以免出现一个地方修改另外一个地方遗漏的情况。目前turbo逻辑filter和map保持一致了。
3. 限定pyav版本。