### PR TITLE
log summarization

### DIFF
--- a/data_juicer/core/data.py
+++ b/data_juicer/core/data.py
@@ -21,6 +21,7 @@ from data_juicer.utils.compress import (CompressionOff,
                                         cleanup_compressed_cache_files,
                                         compress, decompress)
 from data_juicer.utils.fingerprint_utils import generate_fingerprint
+from data_juicer.utils.logger_utils import make_log_summarization
 from data_juicer.utils.process_utils import setup_mp
 
 
@@ -258,6 +259,9 @@ class NestedDataset(Dataset, DJDataset):
             if work_dir and enable_insight_mining:
                 logger.info('Insight mining for each OP...')
                 adapter.insight_mining()
+            # make summarization on the error/warning logs
+            if work_dir:
+                make_log_summarization()
         return dataset
 
     def update_args(self, args, kargs, is_filter=False):

--- a/data_juicer/ops/base_op.py
+++ b/data_juicer/ops/base_op.py
@@ -1,5 +1,4 @@
 import copy
-import traceback
 from functools import wraps
 
 import numpy as np
@@ -62,8 +61,7 @@ def catch_map_batches_exception(method):
             from loguru import logger
             logger.error(
                 f'An error occurred in mapper operation when processing '
-                f'samples {samples}, {type(e)}: {e}')
-            traceback.print_exc()
+                f'samples "{samples}" -- {type(e)}: {e}')
             ret = {key: [] for key in samples.keys()}
             ret[Fields.stats] = []
             ret[Fields.source_file] = []
@@ -103,8 +101,7 @@ def catch_map_single_exception(method, return_sample=True):
                 from loguru import logger
                 logger.error(
                     f'An error occurred in mapper operation when processing '
-                    f'sample {sample}, {type(e)}: {e}')
-                traceback.print_exc()
+                    f'sample "{sample}" -- {type(e)}: {e}')
                 ret = {key: [] for key in sample.keys()}
                 ret[Fields.stats] = []
                 ret[Fields.source_file] = []

--- a/data_juicer/ops/filter/language_id_score_filter.py
+++ b/data_juicer/ops/filter/language_id_score_filter.py
@@ -1,7 +1,5 @@
 from typing import List, Union
 
-from loguru import logger
-
 from data_juicer.utils.constant import Fields, StatsKeys
 from data_juicer.utils.lazy_loader import LazyLoader
 from data_juicer.utils.model_utils import get_model, prepare_model
@@ -55,7 +53,6 @@ class LanguageIDScoreFilter(Filter):
         ft_model = get_model(self.model_key)
         if ft_model is None:
             err_msg = 'Model not loaded. Please retry later.'
-            logger.error(err_msg)
             raise ValueError(err_msg)
         pred = ft_model.predict(text)
         lang_id = pred[0][0].replace('__label__', '')

--- a/data_juicer/utils/logger_utils.py
+++ b/data_juicer/utils/logger_utils.py
@@ -23,6 +23,8 @@ from io import StringIO
 from loguru import logger
 from loguru._file_sink import FileSink
 
+from data_juicer.utils.file_utils import add_suffix_to_filename
+
 LOGGER_SETUP = False
 
 
@@ -141,6 +143,32 @@ def setup_logger(save_dir,
             enqueue=True,
         )
         logger.add(save_file)
+
+    # for interest of levels: debug, error, warning
+    logger.add(
+        add_suffix_to_filename(save_file, '_DEBUG'),
+        level='DEBUG',
+        filter=lambda x: 'DEBUG' == x['level'].name,
+        format=loguru_format,
+        enqueue=True,
+        serialize=True,
+    )
+    logger.add(
+        add_suffix_to_filename(save_file, '_ERROR'),
+        level='ERROR',
+        filter=lambda x: 'ERROR' == x['level'].name,
+        format=loguru_format,
+        enqueue=True,
+        serialize=True,
+    )
+    logger.add(
+        add_suffix_to_filename(save_file, '_WARNING'),
+        level='WARNING',
+        filter=lambda x: 'WARNING' == x['level'].name,
+        format=loguru_format,
+        enqueue=True,
+        serialize=True,
+    )
 
     # redirect stdout/stderr to loguru
     if redirect:


### PR DESCRIPTION
- Unify the error log format for fault tolerance. OPs will raise errors/exceptions instead of writing logs for them.

`An error occurred in mapper operation when processing sample(s) "{sample}" -- {error_type}: {error_message}`

- Extract debug/warning/error log items to separate log files with '_{level}' suffix. e.g.

```
outputs/demo-process/log
├── export_demo-processed.jsonl_time_20250109111158.txt
├── export_demo-processed.jsonl_time_20250109111158_DEBUG.txt
├── export_demo-processed.jsonl_time_20250109111158_ERROR.txt
└── export_demo-processed.jsonl_time_20250109111158_WARNING.txt
```

- After OPs are done, error/warning log summary will be made and output for users, including the number of each type of logs. e.g.

![image](https://github.com/user-attachments/assets/5ff5ab11-2996-4cf1-b2ce-fa367b04f3f8)

