### PR TITLE
Update sdxl_prompt2prompt_mapper.py

### DIFF
--- a/data_juicer/ops/mapper/sdxl_prompt2prompt_mapper.py
+++ b/data_juicer/ops/mapper/sdxl_prompt2prompt_mapper.py
@@ -8,6 +8,8 @@ from data_juicer.ops.base_op import OPERATORS, Mapper
 from data_juicer.ops.op_fusion import LOADED_IMAGES
 from data_juicer.utils.lazy_loader import LazyLoader
 from data_juicer.utils.model_utils import get_model, prepare_model
+from diffusers.models.attention import Attention
+
 
 diffusers = LazyLoader('diffusers', 'diffusers')
 torch = LazyLoader('torch', 'torch')


### PR DESCRIPTION
当前从官方拉取的main分支，在windows10 python3.9环境，使用源码安装方式之后，运行数据处理demo：python tools/process_data.py --config configs/demo/process.yaml时，会报错 AttributeError：module diffusers.models has no attribute attention，根据报错内容定位到源码，sdxl_prompt2prompt_mapper.py 704行 Attention 使用的是注意力机制相关的模块，所以需要显示导入，增加一行代码 from diffusers.models.attention import Attention，成功解决问题