### PR TITLE
Optimize dedup to avoid oom

### DIFF
--- a/tools/distributed_deduplication/dedup_utils.py
+++ b/tools/distributed_deduplication/dedup_utils.py
@@ -92,11 +92,11 @@ def find_components(edges):
     a = edges
     while True:
         b = a.flatMap(large_star_map).groupByKey().flatMap(
-            large_star_reduce).distinct().cache()
+            large_star_reduce).distinct()
         a = b.map(small_star_map).groupByKey().flatMap(
-            small_star_reduce).distinct().cache()
-        changes = a.subtract(b).union(b.subtract(a)).collect()
-        if len(changes) == 0:
+            small_star_reduce).distinct()
+        changes = a.subtract(b).union(b.subtract(a)).count()
+        if changes == 0:
             break
 
     results = a.collect()


### PR DESCRIPTION
- `distinct()` will storage the data, and the downstream will read from the shuffle. We do not need the cache any more.
- Use the `count()` to instead the `collect()` to avoid the drive OOM.