### PR TITLE
fix: image_nsfw_filter.py memory leak. disable gradient

### DIFF
--- a/data_juicer/ops/filter/image_nsfw_filter.py
+++ b/data_juicer/ops/filter/image_nsfw_filter.py
@@ -73,7 +73,8 @@ class ImageNSFWFilter(Filter):
 
         images = [images[key] for key in images]
         inputs = processor(images=images, return_tensors='pt').to(model.device)
-        outputs = model(**inputs)
+        with torch.no_grad():
+            outputs = model(**inputs)
         logits = outputs.logits
         nsfw_scores = [
             float(scores[1]) for scores in torch.softmax(logits, dim=-1)


### PR DESCRIPTION
when using cpu to run this op, memory continuously  rising.