### PR TITLE
Add API service doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,8 @@ Table of Contents
   - [Preprocess Tools](tools/preprocess/README.md)
   - [Postprocess Tools](tools/postprocess/README.md)
   - [Sandbox](docs/Sandbox.md)
-  - [Quality Classifier](tools/quality_classifier/README.md)
+  - [API Service](docs/DJ_service.md)
+  - [Data Scoring](tools/quality_classifier/README.md)
   - [Auto Evaluation](tools/evaluator/README.md)
   - [Third-parties Integration](thirdparty/LLM_ecosystems/README.md)
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -134,7 +134,8 @@ Data-Juicer正在积极更新和维护中，我们将定期强化和新增更多
   - [预处理工具](tools/preprocess/README_ZH.md)
   - [后处理工具](tools/postprocess/README_ZH.md)
   - [沙盒](docs/Sandbox-ZH.md)
-  - [质量分类器](tools/quality_classifier/README_ZH.md)
+  - [API服务化](docs/DJ_service_ZH.md))
+  - [给数据打分](tools/quality_classifier/README_ZH.md)
   - [自动评估](tools/evaluator/README_ZH.md)
   - [第三方集成](thirdparty/LLM_ecosystems/README_ZH.md)
 

--- a/docs/DJ_service.md
+++ b/docs/DJ_service.md
@@ -1,0 +1,80 @@
+English | [中文页面](DJ_service_ZH.md)
+
+To further enhance the user experience of Data-Juicer, we have introduced a new service feature based on API (Service API), enabling users to integrate and utilize Data-Juicer's powerful operator pool in a more convenient way. With this service feature, users can quickly build data processing pipelines without needing to delve into the underlying implementation details of the framework, and seamlessly integrate with existing systems. Additionally, users can achieve environment isolation between different projects through this service. This document will provide a detailed explanation of how to launch and use this service feature, helping you get started quickly and fully leverage the potential of Data-Juicer.
+
+# Start the Service
+Run the following code:
+```bash
+uvicorn service:app
+```
+
+# API Calls
+The API supports calling all functions and classes in Data-Juicer's `__init__.py` (including calling specific functions of a class). Functions are called via GET, while classes are called via POST.
+
+## Protocol
+
+### URL Path
+For GET requests to call functions, the URL path corresponds to the function reference path in the Data-Juicer library. For example, `from data_juicer.config import init_configs` maps to the path `data_juicer/config/init_configs`. For POST requests to call a specific function of a class, the URL path is constructed by appending the function name to the class path in the Data-Juicer library. For instance, calling the `compute_stats_batched` function of the `TextLengthFilter` operator corresponds to the path `data_juicer/ops/filter/TextLengthFilter/compute_stats_batched`.
+
+### Parameters
+When making GET and POST calls, parameters are automatically converted into lists. Additionally, query parameters do not support dictionary transmission. Therefore, if the value of a parameter is a list or dictionary, we uniformly transmit it using `json.dumps` and prepend a special symbol `<json_dumps>` to distinguish it from regular strings.
+
+### Special Cases
+1. For the `cfg` parameter, we default to transmitting it using `json.dumps`, without needing to prepend the special symbol `<json_dumps>`.
+2. For the `dataset` parameter, users can pass the path of the dataset on the server, and the server will load the dataset.
+3. Users can set the `skip_return` parameter. When set to `True`, the result of the function call will not be returned, avoiding errors caused by network transmission issues.
+
+## Function Calls
+GET requests are used for function calls, with the URL path corresponding to the function reference path in the Data-Juicer library. Query parameters are used to pass the function arguments.
+
+For example, the following Python code can be used to call Data-Juicer's `init_configs` function to retrieve all parameters of Data-Juicer:
+
+```python
+import requests
+import json
+
+json_prefix = '<json_dumps>'
+url = 'http://localhost:8000/data_juicer/config/init_configs'
+params = {"args": json_prefix + json.dumps(['--config', './configs/demo/process.yaml'])}
+response = requests.get(url, params=params)
+print(json.loads(response.text))
+```
+
+The corresponding curl command is as follows:
+
+```bash
+curl -G "http://localhost:8000/data_juicer/config/init_configs" \
+     --data-urlencode "args=--config" \
+     --data-urlencode "args=./configs/demo/process.yaml"
+```
+
+## Class Function Calls
+POST requests are used for class function calls, with the URL path constructed by appending the function name to the class path in the Data-Juicer library. Query parameters are used to pass the function arguments, while JSON fields are used to pass the arguments required for the class constructor.
+
+For example, the following Python code can be used to call Data-Juicer's `TextLengthFilter` operator:
+
+```python
+import requests
+import json
+
+json_prefix = '<json_dumps>'
+url = 'http://localhost:8000/data_juicer/ops/filter/TextLengthFilter/compute_stats_batched'
+params = {'samples': json_prefix + json.dumps({'text': ['12345', '123'], '__dj__stats__': [{}, {}]})}
+init_json = {'min_len': 4, 'max_len': 10}
+response = requests.post(url, params=params, json=init_json)
+print(json.loads(response.text))
+```
+
+The corresponding curl command is as follows:
+
+```bash
+curl -X POST \
+  "http://localhost:8000/data_juicer/ops/filter/TextLengthFilter/compute_stats_batched?samples=%3Cjson_dumps%3E%7B%22text%22%3A%20%5B%2212345%22%2C%20%22123%22%5D%2C%20%22__dj__stats__%22%3A%20%5B%7B%7D%2C%20%7B%7D%5D%7D" \
+  -H "Content-Type: application/json" \
+  -d '{"min_len": 4, "max_len": 10}'
+```
+
+**Note**: If you need to call the `run` function of the `Executor` or `Analyzer` classes for data processing and data analysis, you must first call the `init_configs` or `get_init_configs` function to obtain the complete Data-Juicer parameters to construct these two classes. For more details, refer to the demonstration below.
+
+# Demonstration
+We have integrated [AgentScope](https://github.com/modelscope/agentscope) to enable users to invoke Data-Juicer operators for data cleaning through natural language. The operators are invoked via an API service. For the specific code, please refer to [here](../demos/api_service).

--- a/docs/DJ_service_ZH.md
+++ b/docs/DJ_service_ZH.md
@@ -1,0 +1,80 @@
+中文 | [English Page](DJ_service.md) 
+
+为了进一步提升Data-Juicer用户体验，我们新增了基于 API 的服务功能（Service API），使用户能够以更便捷的方式集成和使用 Data-Juicer 的强大算子池。通过该服务功能，用户无需深入了解框架的底层实现细节，即可快速构建数据处理流水线，并与现有系统无缝对接。用户也可通过该服务实现不同project之间的环境隔离。本文档将详细介绍如何启动和使用这一服务功能，帮助您快速上手并充分发挥 Data-Juicer 的潜力。
+
+# 启动服务
+执行如下代码：
+```bash
+uvicorn service:app
+```
+
+# API调用
+API支持调用Data-Juicer所有`__init__.py`中的函数和类（调用类的某个函数）。函数调用GET调用，类通过POST调用。
+
+## 协议
+
+### url路径
+采用GET调用函数，url路径与Data-Juicer库中函数引用路径一致，如`from data_juicer.config import init_configs`对应路径为`data_juicer/config/init_configs`。采用POST调用类的某个函数，url路径与Data-Juicer库中类路径拼接上函数名，如调用`TextLengthFIlter`算子的`compute_stats_batched`函数，对应路径为`data_juicer/ops/filter/TextLengthFilter/compute_stats_batched`。
+
+### 参数
+进行GET和POST调用时，会自动将参数转化为list，同时，查询参数不支持字典传输。于是，如果传递的参数的value是list或dict，我们统一用`json.dumps`传输，并在前面添加特殊符号`<json_dumps>`与一般的string进行区分。
+
+### 特例
+1. 针对`cfg`参数，我们默认采用`json.dumps`传输，无需添加特殊符号`<json_dumps>`。
+2. 针对`dataset`参数，允许用户传输`dataset`在服务器上的路径，sever将加载dataset。
+3. 允许用户设定`skip_return`参数，为`True`时将不返回函数调用的结果，避免一些网络无法传输带来的错误。
+
+## 函数调用
+采用GET调用，url路径与Data-Juicer库中函数引用路径一致，查询参数用来传递函数的参数。
+
+例如，可用如下python代码调用Data-Juicer的参数init函数`init_configs`，获取Data-Juicer所有参数。
+
+```python
+import requests
+import json
+
+json_prefix = '<json_dumps>'
+url = 'http://localhost:8000/data_juicer/config/init_configs'
+params = {"args": json_prefix + json.dumps(['--config', './configs/demo/process.yaml'])}
+response = requests.get(url, params=params)
+print(json.loads(response.text))
+```
+
+对应的curl代码如下：
+
+```bash
+curl -G "http://localhost:8000/data_juicer/config/init_configs" \
+     --data-urlencode "args=--config" \
+     --data-urlencode "args=./configs/demo/process.yaml"
+```
+
+## 类的函数调用
+采用POST调用，url路径与Data-Juicer库中类路径拼接上函数名，查询参数用来传递函数的参数，JSON字段用来传递类构造函数所需参数。
+
+例如，可用如下python代码调用Data-Juicer的`TextLengthFIlter`算子。
+```python
+import requests
+import json
+
+json_prefix = '<json_dumps>'
+url = 'http://localhost:8000/data_juicer/ops/filter/TextLengthFilter/compute_stats_batched'
+params = {'samples': json_prefix + json.dumps({'text': ['12345', '123'], '__dj__stats__': [{}, {}]})}
+init_json = {'min_len': 4, 'max_len': 10}
+response = requests.post(url, params=params, json=init_json)
+print(json.loads(response.text))
+```
+
+对应的curl代码如下：
+
+```bash
+curl -X POST \
+  "http://localhost:8000/data_juicer/ops/filter/TextLengthFilter/compute_stats_batched?samples=%3Cjson_dumps%3E%7B%22text%22%3A%20%5B%2212345%22%2C%20%22123%22%5D%2C%20%22__dj__stats__%22%3A%20%5B%7B%7D%2C%20%7B%7D%5D%7D" \
+  -H "Content-Type: application/json" \
+  -d '{"min_len": 4, "max_len": 10}'
+```
+
+
+注：如果需要调用`Executor`类或`Analyzer`类的`run`函数进行数据处理和数据分析，需要先调用`init_configs`或`get_init_configs`函数获取完整的Data-Juicer参数来构造这两个类。具体可参考如下演示。
+
+# 演示
+我们结合[AgentScope](https://github.com/modelscope/agentscope)实现了用户通过自然语言调用Data-Juicer算子进行数据清洗的功能，算子采用API服务的方式进行调用。具体代码请参考[这里](../demos/api_service)。

--- a/environments/minimal_requires.txt
+++ b/environments/minimal_requires.txt
@@ -31,7 +31,7 @@ dill==0.3.4
 psutil
 pydantic>=2.0
 Pillow
-fastapi[standard]>=0.115
+fastapi[standard]>=0.110
 httpx
 wordcloud
 jsonlines

--- a/environments/minimal_requires.txt
+++ b/environments/minimal_requires.txt
@@ -31,7 +31,7 @@ dill==0.3.4
 psutil
 pydantic>=2.0
 Pillow
-fastapi[standard]>=0.100
+fastapi[standard]>=0.115
 httpx
 wordcloud
 jsonlines

--- a/tools/quality_classifier/README.md
+++ b/tools/quality_classifier/README.md
@@ -1,4 +1,16 @@
-# Quality Classifier Toolkit
+
+# Data Scoring Capabilities
+
+Data-Juicer provides a set of data scoring capabilities to help you evaluate your datasets.
+
+- All [Filter Operators](../../docs/Operators.md) include a sub-process called `compute_stats`, which calculates statistical measurements based on a pre-defined functional goal of the operator. These measurements are typically derived using simple rules, auxiliary models, or advanced algorithms, such as for perplexity, length, modality matching scores, etc. The `Analyzer` will automatically aggregate these statistics and report them in the resulting dataset.
+  
+- Prompt-based LLM scoring operators are also available, such as `llm_api_difficulty_score_filter` and `llm_api_quality_score_filter`. These operators come with default prompts for general use cases but also offer flexibility for users to customize their own models or specific requirements.
+
+- Additionally, we provide a toolkit to reproduce the GPT-3 quality classifier, as described in the following section.
+
+
+# Quality Classifier Toolkit (GPT-3 Reproduced)
 
 Help you reproduce and apply quality classifier to your web datasets similar to GPT-3 quality classifier.
 

--- a/tools/quality_classifier/README_ZH.md
+++ b/tools/quality_classifier/README_ZH.md
@@ -1,4 +1,14 @@
-# Quality Classifier Toolkit
+# 数据打分能力
+
+Data-Juicer 提供了一组数据打分能力，可帮助您评估数据集。
+
+- 所有 [Filter OPs](../../docs/Operators.md) 都包含一个名为 `compute_stats` 的子过程，该过程根据运算符的预定义功能目标，计算统计测量值。这些测量值通常使用简单规则、辅助模型或高级算法得出，例如困惑度、长度、模态匹配分数等。`Analyzer` 将自动汇总这些统计数据并将其报告在结果数据集中。
+
+- 我们也提供了基于提示词的 LLM 评分算子，例如 `llm_api_difficulty_score_filter` 和 `llm_api_quality_score_filter`。这些算子带有针对一般用例的默认提示，但也为用户提供了灵活性，以自定义特定模型或特定要求。
+
+- 此外，我们还提供了一个工具包来复现 GPT-3 质量分类器，如下一节所述。
+
+# 复现GPT3的质量分类器套件
 
 帮助您复现类似于 GPT-3 质量分类器并将其应用到您的 Web 数据集。
 


### PR DESCRIPTION
1. Add API service doc.
2. Our test fail in old version of `fastapi`. So I update it in env requirement.
3. Add more available function for OPs.
4. Add json dump parser for common list or dict params.