### PR TITLE
set temp_parser.usage to argparse.SUPPRESS, skip too much help log

### DIFF
--- a/data_juicer/config/config.py
+++ b/data_juicer/config/config.py
@@ -1,3 +1,4 @@
+import argparse
 import copy
 import json
 import os
@@ -713,6 +714,8 @@ def update_op_process(cfg, parser):
 
     # check the op params via type hint
     temp_parser = copy.deepcopy(parser)
+    temp_parser.usage = argparse.SUPPRESS
+
     recognized_args = set([
         action.dest for action in parser._actions
         if hasattr(action, 'dest') and isinstance(action, ActionTypeHint)

--- a/data_juicer/config/config.py
+++ b/data_juicer/config/config.py
@@ -36,7 +36,9 @@ def init_configs(args: Optional[List[str]] = None, which_entry: object = None):
     :param which_entry: which entry to init configs (executor/analyzer)
     :return: a global cfg object used by the DefaultExecutor or Analyzer
     """
-    parser = ArgumentParser(default_env=True, default_config_files=None)
+    parser = ArgumentParser(default_env=True,
+                            default_config_files=None,
+                            usage=argparse.SUPPRESS)
 
     # required but mutually exclusive args group
     required_group = parser.add_mutually_exclusive_group(required=True)
@@ -714,7 +716,6 @@ def update_op_process(cfg, parser):
 
     # check the op params via type hint
     temp_parser = copy.deepcopy(parser)
-    temp_parser.usage = argparse.SUPPRESS
 
     recognized_args = set([
         action.dest for action in parser._actions

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -19,19 +19,19 @@ WORKDIR = os.path.join(os.getcwd(), 'outputs/demo')
 
 class ConfigTest(DataJuicerTestCaseBase):
 
-    def test_help_info(self):
-        out = StringIO()
-        with redirect_stdout(out), self.assertRaises(SystemExit):
-            _ = init_configs(args=['--help'])
-        out_str = out.getvalue()
-        self.assertIn('usage:', out_str, 'lacks message for command beginning')
-        self.assertIn('--config CONFIG', out_str,
-                      'lacks message for positional argument')
-        self.assertIn('[--project_name PROJECT_NAME]', out_str,
-                      'lacks message for optional argument')
-        self.assertIn(
-            'Number of processes to process dataset. (type:', out_str,
-            'the help message of `np` argument does not show as expected')
+    # def test_help_info(self):
+    #     out = StringIO()
+    #     with redirect_stdout(out), self.assertRaises(SystemExit):
+    #         _ = init_configs(args=['--help'])
+    #     out_str = out.getvalue()
+    #     self.assertIn('usage:', out_str, 'lacks message for command beginning')
+    #     self.assertIn('--config CONFIG', out_str,
+    #                   'lacks message for positional argument')
+    #     self.assertIn('[--project_name PROJECT_NAME]', out_str,
+    #                   'lacks message for optional argument')
+    #     self.assertIn(
+    #         'Number of processes to process dataset. (type:', out_str,
+    #         'the help message of `np` argument does not show as expected')
 
     def test_yaml_cfg_file(self):
         out = StringIO()

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -19,19 +19,19 @@ WORKDIR = os.path.join(os.getcwd(), 'outputs/demo')
 
 class ConfigTest(DataJuicerTestCaseBase):
 
-    # def test_help_info(self):
-    #     out = StringIO()
-    #     with redirect_stdout(out), self.assertRaises(SystemExit):
-    #         _ = init_configs(args=['--help'])
-    #     out_str = out.getvalue()
-    #     self.assertIn('usage:', out_str, 'lacks message for command beginning')
-    #     self.assertIn('--config CONFIG', out_str,
-    #                   'lacks message for positional argument')
-    #     self.assertIn('[--project_name PROJECT_NAME]', out_str,
-    #                   'lacks message for optional argument')
-    #     self.assertIn(
-    #         'Number of processes to process dataset. (type:', out_str,
-    #         'the help message of `np` argument does not show as expected')
+    def test_help_info(self):
+        out = StringIO()
+        with redirect_stdout(out), self.assertRaises(SystemExit):
+            _ = init_configs(args=['--help'])
+        out_str = out.getvalue()
+        # self.assertIn('usage:', out_str, 'lacks message for command beginning')
+        self.assertIn('--config CONFIG', out_str,
+                      'lacks message for positional argument')
+        self.assertIn('--project_name PROJECT_NAME', out_str,
+                      'lacks message for optional argument')
+        self.assertIn(
+            'Number of processes to process dataset. (type:', out_str,
+            'the help message of `np` argument does not show as expected')
 
     def test_yaml_cfg_file(self):
         out = StringIO()


### PR DESCRIPTION
When op arg parsing fails, help info for all ops will be printed. too many logs will flush previous logs, it's hard to find useful information.