### PR TITLE
Fix StreamToLoguru compatibility issue with torch._dynamo

### DIFF
--- a/data_juicer/utils/logger_utils.py
+++ b/data_juicer/utils/logger_utils.py
@@ -82,7 +82,7 @@ class StreamToLoguru:
 
     def flush(self):
         self.buffer.flush()
-        
+
     def isatty(self):
         return False  # Log streams are usually not terminal devices
 

--- a/data_juicer/utils/logger_utils.py
+++ b/data_juicer/utils/logger_utils.py
@@ -82,6 +82,9 @@ class StreamToLoguru:
 
     def flush(self):
         self.buffer.flush()
+        
+    def isatty(self):
+        return False  # Log streams are usually not terminal devices
 
 
 def redirect_sys_output(log_level='INFO'):


### PR DESCRIPTION
The StreamToLoguru class does not implement the isatty method, and torch._dynamo tries to call sys.stdout.isatty() at runtime:
` torch._dynamo.exc.InternalTorchDynamoError: AttributeError: 'StreamToLoguru' object has no attribute 'isatty'`

So add the isatty method to the StreamToLoguru class and set its return value to False. this indicates that the log stream is not an endpoint device, in line with the actual purpose of log streams