### PR TITLE
build: add snowballstemmer dependency range

### DIFF
--- a/environments/dev_requires.txt
+++ b/environments/dev_requires.txt
@@ -3,5 +3,6 @@ pre-commit
 sphinx
 sphinx-autobuild
 sphinx_rtd_theme
+snowballstemmer>=2.2.0,<3.0.0
 recommonmark
 wandb<=0.19.0


### PR DESCRIPTION
The snowballstemmer package released a new version on May 8th with breaking changes that affect the porter stemmer functionality. This PR updates the dependency constraints to fix the following error that occurs during document preparation:

```python
Exception occurred:
  File "/opt/hostedtoolcache/Python/3.10.17/x64/lib/python3.10/site-packages/snowballstemmer/__init__.py", line 27, in stemmer
    raise KeyError("Stemming algorithm '%s' not found" % lang)
KeyError: "Stemming algorithm 'porter' not found"
```

So add version constraint for snowballstemmer: >=2.2.0,<3.0.0