### PR TITLE
add generate_uv_lock util to exclude sandbox when generating uv.lock

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ dependencies = [
     "mwparserfromhell",
     "regex",  # regular expressions
     "tomli",
+    "tomli-w",
     "gitpython"
 ]
 

--- a/tools/generate_uv_lock.py
+++ b/tools/generate_uv_lock.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""
+Utility script to generate uv.lock file excluding sandbox dependencies.
+"""
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import tomli
+import tomli_w
+
+
+def read_pyproject_toml():
+    """Read and parse pyproject.toml file."""
+    pyproject_path = Path(__file__).parent.parent / 'pyproject.toml'
+    if not pyproject_path.exists():
+        raise FileNotFoundError(
+            f'pyproject.toml not found at {pyproject_path}')
+    with open(pyproject_path, 'rb') as f:
+        return tomli.load(f)
+
+
+def check_uv_installed():
+    """Check if uv is installed and available in PATH."""
+    try:
+        subprocess.run(['uv', '--version'], capture_output=True, check=True)
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        raise RuntimeError(
+            'uv is not installed or not in PATH. Please install it first: '
+            'pip install uv')
+
+
+def generate_uv_lock():
+    """Generate uv.lock file excluding sandbox dependencies."""
+    # Check prerequisites
+    check_uv_installed()
+
+    # Read pyproject.toml
+    pyproject = read_pyproject_toml()
+    pyproject_path = Path(__file__).parent.parent / 'pyproject.toml'
+
+    # Backup original pyproject.toml
+    backup_path = pyproject_path.with_suffix('.toml.bak')
+    shutil.copy2(pyproject_path, backup_path)
+
+    try:
+        # Create modified pyproject.toml without sandbox
+        if 'sandbox' in pyproject['project']['optional-dependencies']:
+            del pyproject['project']['optional-dependencies']['sandbox']
+
+        # Write modified pyproject.toml
+        toml_str = tomli_w.dumps(pyproject)
+        with open(pyproject_path, 'w', encoding='utf-8') as f:
+            f.write(toml_str)
+
+        # Generate uv.lock using uv lock
+        subprocess.run(['uv', 'lock'], check=True)
+        print('Successfully generated uv.lock')
+    except Exception as e:
+        print(f'Error: {e}', file=sys.stderr)
+        sys.exit(1)
+    finally:
+        # Restore original pyproject.toml
+        shutil.copy2(backup_path, pyproject_path)
+        backup_path.unlink()
+
+
+def main():
+    """Main entry point."""
+    try:
+        generate_uv_lock()
+    except Exception as e:
+        print(f'Error: {e}', file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/uv.lock
+++ b/uv.lock
@@ -4829,6 +4829,7 @@ dependencies = [
     { name = "streamlit" },
     { name = "tabulate" },
     { name = "tomli" },
+    { name = "tomli-w" },
     { name = "tqdm" },
     { name = "uv" },
     { name = "wget" },
@@ -5082,6 +5083,7 @@ requires-dist = [
     { name = "toml", marker = "extra == 'all'" },
     { name = "toml", marker = "extra == 'dev'" },
     { name = "tomli" },
+    { name = "tomli-w" },
     { name = "torch", marker = "extra == 'all'", specifier = ">=1.11.0" },
     { name = "torch", marker = "extra == 'generic'", specifier = ">=1.11.0" },
     { name = "torchaudio", marker = "extra == 'all'" },
@@ -7445,6 +7447,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/5b/b9/1ed31d167be802da0fc95020d04cd27b7d7065cc6fbefdd2f9186f60d7bd/tomli-2.2.1-cp313-cp313-win32.whl", hash = "sha256:d3f5614314d758649ab2ab3a62d4f2004c825922f9e370b29416484086b264ec", size = 98724, upload-time = "2024-11-27T22:38:32.837Z" },
     { url = "https://files.pythonhosted.org/packages/c7/32/b0963458706accd9afcfeb867c0f9175a741bf7b19cd424230714d722198/tomli-2.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:a38aa0308e754b0e3c67e344754dff64999ff9b513e691d0e786265c93583c69", size = 109383, upload-time = "2024-11-27T22:38:34.455Z" },
     { url = "https://files.pythonhosted.org/packages/6e/c2/61d3e0f47e2b74ef40a68b9e6ad5984f6241a942f7cd3bbfbdbd03861ea9/tomli-2.2.1-py3-none-any.whl", hash = "sha256:cb55c73c5f4408779d0cf3eef9f762b9c9f147a77de7b258bef0a5628adc85cc", size = 14257, upload-time = "2024-11-27T22:38:35.385Z" },
+]
+
+[[package]]
+name = "tomli-w"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/75/241269d1da26b624c0d5e110e8149093c759b7a286138f4efd61a60e75fe/tomli_w-1.2.0.tar.gz", hash = "sha256:2dd14fac5a47c27be9cd4c976af5a12d87fb1f0b4512f81d69cce3b35ae25021", size = 7184, upload-time = "2025-01-15T12:07:24.262Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl", hash = "sha256:188306098d013b691fcadc011abd66727d3c414c571bb01b1a174ba8c983cf90", size = 6675, upload-time = "2025-01-15T12:07:22.074Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
sandbox includes vbench and such, will introduce a lot of dependency conflicts.
when uv generates uv.lock, it includes everything defined in pyproject.toml even the optional ones. 
the util is to exclude sandbox dependencies while generating uv.lock for the deterministic dependency resolution.