### PR TITLE
optimize startup time

### DIFF
--- a/data_juicer/config/config.py
+++ b/data_juicer/config/config.py
@@ -482,8 +482,6 @@ def init_configs(args: Optional[List[str]] = None, which_entry: object = None):
             with timing_context('Parsing arguments'):
                 cfg = parser.parse_args(args=args)
 
-                logger.info(f'cfg: {cfg}')
-
                 # check the entry
                 from data_juicer.core.analyzer import Analyzer
                 if not isinstance(which_entry, Analyzer) and cfg.auto:

--- a/data_juicer/config/config.py
+++ b/data_juicer/config/config.py
@@ -441,7 +441,7 @@ def init_configs(args: Optional[List[str]] = None, which_entry: object = None):
                 i = 0
                 while i < len(args):
                     arg = args[i]
-                    # Always keep --help, --config, and --auto as they are required/helpful
+                    # Handle --help, --config, and --auto in first pass
                     if arg == '--help':
                         essential_args.append(arg)
                     elif arg == '--config':
@@ -452,27 +452,7 @@ def init_configs(args: Optional[List[str]] = None, which_entry: object = None):
                             i += 1
                     elif arg == '--auto':
                         essential_args.append(arg)
-                    # For other essential arguments
-                    elif arg.startswith('--'):
-                        if any(
-                                arg.startswith(f'--{essential}')
-                                for essential in [
-                                    'auto_num', 'hpo_config',
-                                    'data_probe_algo', 'data_probe_ratio',
-                                    'project_name', 'executor_type',
-                                    'dataset_path', 'dataset', 'export_path',
-                                    'np', 'text_keys', 'debug', 'ray_address'
-                                ]):
-                            essential_args.append(arg)
-                            # If the next arg is not a flag, it's a value for this arg
-                            if i + 1 < len(args) and not args[
-                                    i + 1].startswith('--'):
-                                essential_args.append(args[i + 1])
-                                i += 1
                     i += 1
-
-            logger.debug(f'Args: {args}')
-            logger.debug(f'Essential arguments: {essential_args}')
 
             # Parse essential arguments first
             essential_cfg = parser.parse_args(args=essential_args)

--- a/data_juicer/config/config.py
+++ b/data_juicer/config/config.py
@@ -30,6 +30,7 @@ def timing_context(description):
     start_time = time.time()
     yield
     elapsed_time = time.time() - start_time
+    # Use a consistent format that won't be affected by logger reconfiguration
     logger.info(f'{description} took {elapsed_time:.2f} seconds')
 
 

--- a/data_juicer/ops/__init__.py
+++ b/data_juicer/ops/__init__.py
@@ -1,9 +1,24 @@
+import time
+from contextlib import contextmanager
+
+from loguru import logger
+
+
+@contextmanager
+def timing_context(description):
+    start_time = time.time()
+    yield
+    elapsed_time = time.time() - start_time
+    logger.info(f'{description} took {elapsed_time:.2f} seconds')
+
+
 # yapf: disable
-from . import aggregator, deduplicator, filter, grouper, mapper, selector
-from .base_op import (NON_STATS_FILTERS, OPERATORS, TAGGING_OPS, UNFORKABLE,
-                      Aggregator, Deduplicator, Filter, Grouper, Mapper,
-                      Selector)
-from .load import load_ops
+with timing_context('Importing operator modules'):
+    from . import aggregator, deduplicator, filter, grouper, mapper, selector
+    from .base_op import (NON_STATS_FILTERS, OPERATORS, TAGGING_OPS,
+                          UNFORKABLE, Aggregator, Deduplicator, Filter,
+                          Grouper, Mapper, Selector)
+    from .load import load_ops
 
 __all__ = [
     'load_ops',

--- a/data_juicer/ops/base_op.py
+++ b/data_juicer/ops/base_op.py
@@ -319,11 +319,16 @@ class Mapper(OP):
                 skip_op_error=self.skip_op_error,
                 op_name=self._name)
 
+    # set the process method is not allowed to be overridden
     @classmethod
     def __init_subclass__(cls, **kwargs):
-        """Register the operator to the registry."""
-        super().__init_subclass__(**kwargs)
-        OPERATORS.register_module(cls.__name__.lower())(cls)
+        not_allowed_list = ['process']
+        for method_name in not_allowed_list:
+            if method_name in cls.__dict__:
+                raise TypeError(
+                    f'Method {method_name} cannot be overridden by subclass '
+                    f'{cls.__name__}. Please implement {method_name}_single '
+                    f'or {method_name}_batched.')
 
     def __call__(self, *args, **kwargs):
         return self.process(*args, **kwargs)
@@ -397,7 +402,6 @@ class Filter(OP):
         """
         super(Filter, self).__init__(*args, **kwargs)
         self.stats_export_path = kwargs.get('stats_export_path', None)
-        self._stats = {}
 
         # runtime wrappers
         if self.is_batched_op():
@@ -420,12 +424,16 @@ class Filter(OP):
                 skip_op_error=self.skip_op_error,
                 op_name=self._name)
 
+    # set the process method is not allowed to be overridden
     @classmethod
     def __init_subclass__(cls, **kwargs):
-        """Register the filter to the registry."""
-        super().__init_subclass__(**kwargs)
-        if not hasattr(cls, '_stats'):
-            NON_STATS_FILTERS.register_module(cls.__name__.lower())(cls)
+        not_allowed_list = ['compute_stats', 'process']
+        for method_name in not_allowed_list:
+            if method_name in cls.__dict__:
+                raise TypeError(
+                    f'Method {method_name} cannot be overridden by subclass '
+                    f'{cls.__name__}. Please implement {method_name}_single '
+                    f'or {method_name}_batched.')
 
     def __call__(self, *args, **kwargs):
         return self.compute_stats(*args, **kwargs)

--- a/data_juicer/ops/base_op.py
+++ b/data_juicer/ops/base_op.py
@@ -319,15 +319,11 @@ class Mapper(OP):
                 skip_op_error=self.skip_op_error,
                 op_name=self._name)
 
-    # set the process method is not allowed to be overridden
+    @classmethod
     def __init_subclass__(cls, **kwargs):
-        not_allowed_list = ['process']
-        for method_name in not_allowed_list:
-            if method_name in cls.__dict__:
-                raise TypeError(
-                    f'Method {method_name} cannot be overridden by subclass '
-                    f'{cls.__name__}. Please implement {method_name}_single '
-                    f'or {method_name}_batched.')
+        """Register the operator to the registry."""
+        super().__init_subclass__(**kwargs)
+        OPERATORS.register_module(cls.__name__.lower())(cls)
 
     def __call__(self, *args, **kwargs):
         return self.process(*args, **kwargs)
@@ -401,6 +397,7 @@ class Filter(OP):
         """
         super(Filter, self).__init__(*args, **kwargs)
         self.stats_export_path = kwargs.get('stats_export_path', None)
+        self._stats = {}
 
         # runtime wrappers
         if self.is_batched_op():
@@ -423,15 +420,12 @@ class Filter(OP):
                 skip_op_error=self.skip_op_error,
                 op_name=self._name)
 
-    # set the process method is not allowed to be overridden
+    @classmethod
     def __init_subclass__(cls, **kwargs):
-        not_allowed_list = ['compute_stats', 'process']
-        for method_name in not_allowed_list:
-            if method_name in cls.__dict__:
-                raise TypeError(
-                    f'Method {method_name} cannot be overridden by subclass '
-                    f'{cls.__name__}. Please implement {method_name}_single '
-                    f'or {method_name}_batched.')
+        """Register the filter to the registry."""
+        super().__init_subclass__(**kwargs)
+        if not hasattr(cls, '_stats'):
+            NON_STATS_FILTERS.register_module(cls.__name__.lower())(cls)
 
     def __call__(self, *args, **kwargs):
         return self.compute_stats(*args, **kwargs)

--- a/data_juicer/utils/logger_utils.py
+++ b/data_juicer/utils/logger_utils.py
@@ -132,7 +132,7 @@ def setup_logger(save_dir,
         return
 
     loguru_format = (
-        '<green>{time:YYYY-MM-DD HH:mm:ss}</green> | '
+        '<green>{time:YYYY-MM-DD HH:mm:ss.SSS}</green> | '
         '<level>{level: <8}</level> | '
         '<cyan>{name}</cyan>:<cyan>{line}</cyan> - <level>{message}</level>')
 

--- a/tools/process_data.py
+++ b/tools/process_data.py
@@ -1,18 +1,35 @@
+import time
+from contextlib import contextmanager
+
 from loguru import logger
 
 from data_juicer.config import init_configs
 from data_juicer.core import DefaultExecutor
 
 
+@contextmanager
+def timing_context(description):
+    start_time = time.time()
+    yield
+    elapsed_time = time.time() - start_time
+    logger.info(f'{description} took {elapsed_time:.2f} seconds')
+
+
 @logger.catch(reraise=True)
 def main():
-    cfg = init_configs()
-    if cfg.executor_type == 'default':
-        executor = DefaultExecutor(cfg)
-    elif cfg.executor_type == 'ray':
-        from data_juicer.core.executor.ray_executor import RayExecutor
-        executor = RayExecutor(cfg)
-    executor.run()
+    with timing_context('Total initialization time'):
+        with timing_context('Loading configuration'):
+            cfg = init_configs()
+
+        with timing_context('Initializing executor'):
+            if cfg.executor_type == 'default':
+                executor = DefaultExecutor(cfg)
+            elif cfg.executor_type == 'ray':
+                from data_juicer.core.executor.ray_executor import RayExecutor
+                executor = RayExecutor(cfg)
+
+        with timing_context('Running executor'):
+            executor.run()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
optimize dj-process startup time from ~80seconds to ~6 seconds (10X speed up) by:

1. argparse.parse_args uses two-phase argument parsing:
- Essential arguments are handled as usual.
- OP optional arguments are only imported when the corresponding OP is used.

2. update_op_process:
- Only processes arguments for the OPs that are actually used.
- Several optimizations: replaced list comprehensions with sets, removed unnecessary deep copies, and eliminated redundant type checks.

confirmed the generated config table are exactly the same.