### PR TITLE
fix(MCP): Ensure complete parameter description extraction

### DIFF
--- a/data_juicer/tools/DJ_mcp_granular_ops.py
+++ b/data_juicer/tools/DJ_mcp_granular_ops.py
@@ -29,8 +29,8 @@ def create_operator_function(op, mcp):
     This function dynamically creates a function that can be registered as an MCP tool,
     with proper signature and documentation based on the operator's __init__ method.
     """
-    sig = op["signature"]
-    docstring = op["description"]
+    sig = op["sig"]
+    docstring = op["desc"]
     param_docstring = op["param_desc"]
 
     # Create new function signature with dataset_path as first parameter

--- a/data_juicer/tools/DJ_mcp_recipe_flow.py
+++ b/data_juicer/tools/DJ_mcp_recipe_flow.py
@@ -74,7 +74,7 @@ def get_data_processing_ops(
 
     ops_dict = dict()
     for op in op_results:
-        ops_dict[op["name"]] = "\n".join([op["description"], op["param_desc"], "Parameters: ", str(op["signature"])])
+        ops_dict[op["name"]] = "\n".join([op["desc"], op["param_desc"], "Parameters: ", str(op["sig"])])
 
     return ops_dict
 

--- a/data_juicer/tools/op_search.py
+++ b/data_juicer/tools/op_search.py
@@ -24,9 +24,9 @@ class OPRecord:
         return {
             "type": self.type,
             "name": self.name,
-            "description": self.desc,
+            "desc": self.desc,
             "tags": self.tags,
-            "signature": self.sig,
+            "sig": self.sig,
             "param_desc": self.param_desc,
         }
 
@@ -145,10 +145,9 @@ def extract_param_docstring(docstring):
     param_docstring = ""
     if not docstring:
         return param_docstring
-    param_pattern = re.compile(r"(:param\s+(?!args|kwargs)\w+:\s+([^:]*))")
-    matches = param_pattern.findall(docstring)
-    for match in matches:
-        param_docstring += f"    {match[0]}\n"
+    param_docstring = ":param ".join(docstring.split(":param"))
+    if ":param" not in param_docstring:
+        return ""
     return param_docstring
 
 


### PR DESCRIPTION
Fixes an issue where `op_search`'s parameter description extraction was incomplete in certain scenarios.
And refined `op_record`'s dictionary key naming for improved conciseness.