### PR TITLE
docs: add Sphinx video link transforms; refresh README; expose all releases ≥ v1.4.0 in multi-version docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Data-Juicer is being actively updated and maintained. We will periodically enhan
 
 [Demo Video] DataJuicer-Agent: Quick start your data processing journey!
 
-https://github.com/user-attachments/assets/58aea900-e51f-4ec2-b1c0-eead97967893
+https://github.com/user-attachments/assets/6eb726b7-6054-4b0c-905e-506b2b9c7927
 
 [Demo Video] DataJuicer-Sandbox: Better data-model co-dev at a lower cost!
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -32,7 +32,7 @@ Data-Juicer正在积极更新和维护中，我们将定期强化和新增更多
 
 [Demo Video] DataJuicer-Agent:数据处理，即刻启程！
 
-https://github.com/user-attachments/assets/58aea900-e51f-4ec2-b1c0-eead97967893
+https://github.com/user-attachments/assets/6eb726b7-6054-4b0c-905e-506b2b9c7927
 
 [Demo Video] DataJuicer-Sandbox: 降本增效，优化数据-模型协同开发！
 

--- a/docs/sphinx_doc/source/conf.py
+++ b/docs/sphinx_doc/source/conf.py
@@ -15,7 +15,11 @@ from sphinx import project as sphinx_project
 release = version
 
 # -- Path setup --------------------------------------------------------------
+current_dir = os.path.dirname(__file__)
 sys.path.insert(0, os.path.abspath("../../"))
+sys.path.insert(0, current_dir)
+
+from custom_myst import ReplaceVideoLinksTransform
 
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
@@ -51,7 +55,7 @@ myst_enable_extensions = [
 smv_tag_whitelist = rf"^v{release}$"
 smv_branch_whitelist = r"^main$"
 smv_released_pattern = r"^refs/tags/v\d+\.\d+\.\d+$"
-smv_remote_whitelist = r'^origin$'
+smv_remote_whitelist = r"^origin$"
 
 # apidoc settings
 apidoc_module_dir = "../../../data_juicer"
@@ -72,7 +76,7 @@ exclude_patterns = ["build", "demos/process_video_on_ray/data/Note.md"]
 # The theme to use for HTML and HTML Help pages.
 # See the documentation for a list of builtin themes.
 html_theme = "furo"
-html_title = "data-juicer"
+html_title = "Data Juicer"
 
 # Sidebar configuration
 html_sidebars = {
@@ -201,30 +205,6 @@ def update_metadata_docnames(app, config):
     for version_name, _ in metadata.items():
         app.config.smv_metadata[version_name]["docnames"] = updated_docnames
 
-def versions_a_lt_or_eq_to_b(version_a, version_b):
-
-    def is_valid_version(version):
-        return bool(re.match(r"^v\d+\.\d+\.\d+$", version))
-
-    if not is_valid_version(version_a):
-        return False
-
-    if not is_valid_version(version_b):
-        raise ValueError(f"Invalid version format for version_b: {version_b}")
-
-    try:
-        parts_a = [int(x) for x in version_a[1:].split(".")]
-        parts_b = [int(x) for x in version_b[1:].split(".")]
-
-        for i in range(3):
-            if parts_a[i] < parts_b[i]:
-                return True
-            elif parts_a[i] > parts_b[i]:
-                return False
-
-        return True
-    except ValueError:
-        raise ValueError("Version numbers must be numeric")
 
 def rebuild_source_dir(app, config):
     """Rebuild source directory for documentation"""
@@ -298,6 +278,7 @@ def setup(app):
     """Setup Sphinx application hooks"""
     current_version = app.config.smv_current_version
     print(f"Current version: {current_version}")
+    app.add_transform(ReplaceVideoLinksTransform)
     app.config.smv_latest_version = f"v{release}"
     app.connect("config-inited", copy_sphinx_doc_to_build)
     app.connect("config-inited", rebuild_source_dir)

--- a/docs/sphinx_doc/source/custom_myst.py
+++ b/docs/sphinx_doc/source/custom_myst.py
@@ -1,22 +1,22 @@
 from docutils import nodes
 from sphinx.transforms import SphinxTransform
 
+VIDEO_LINK_PREFIX = "https://github.com/user-attachments/assets/"
 
 class ReplaceVideoLinksTransform(SphinxTransform):
     default_priority = 900
 
     def apply(self):
-        video_link = "https://github.com/user-attachments/assets/"
 
         for node in self.document.traverse(nodes.reference):
             uri = node.get("refuri", "")
-            if uri.startswith(video_link):
-                video_html = f"""
-<video controls width="100%" height="auto" playsinline>
-<source src="{uri}" type="video/mp4">
-Your browser does not support the video tag.
-</video>
-"""
+            if uri.startswith(VIDEO_LINK_PREFIX):
+                video_html = "\n".join([
+                    '<video controls width="100%" height="auto" playsinline>',
+                    f'  <source src="{uri}" type="video/mp4">',
+                    '  Your browser does not support the video tag.',
+                    '</video>',
+                ])
 
                 raw_node = nodes.raw("", video_html, format="html")
                 parent = node.parent

--- a/docs/sphinx_doc/source/custom_myst.py
+++ b/docs/sphinx_doc/source/custom_myst.py
@@ -1,0 +1,24 @@
+from docutils import nodes
+from sphinx.transforms import SphinxTransform
+
+
+class ReplaceVideoLinksTransform(SphinxTransform):
+    default_priority = 900
+
+    def apply(self):
+        video_link = "https://github.com/user-attachments/assets/"
+
+        for node in self.document.traverse(nodes.reference):
+            uri = node.get("refuri", "")
+            if uri.startswith(video_link):
+                video_html = f"""
+<video controls width="100%" height="auto" playsinline>
+<source src="{uri}" type="video/mp4">
+Your browser does not support the video tag.
+</video>
+"""
+
+                raw_node = nodes.raw("", video_html, format="html")
+                parent = node.parent
+                index = parent.index(node)
+                parent.replace(node, raw_node)


### PR DESCRIPTION
As stated in the title, this PR:
- Adds support for Sphinx video link transforms,
- Updates the README, replacing the demo video link with a higher-resolution version,
- Publishes all docs for releases ≥ v1.4.0 in the multi-version documentation site.

Updated video link:

https://github.com/user-attachments/assets/6eb726b7-6054-4b0c-905e-506b2b9c7927