### PR TITLE
refactor: move special token updates in config setup

### DIFF
--- a/data_juicer/config/config.py
+++ b/data_juicer/config/config.py
@@ -665,12 +665,6 @@ def init_setup_from_cfg(cfg: Namespace, load_configs_only=False):
     else:
         cfg.ds_cache_dir = str(config.HF_DATASETS_CACHE)
 
-    # update special tokens
-    SpecialTokens.image = cfg.get("image_special_token", SpecialTokens.image)
-    SpecialTokens.audio = cfg.get("audio_special_token", SpecialTokens.audio)
-    SpecialTokens.video = cfg.get("video_special_token", SpecialTokens.video)
-    SpecialTokens.eoc = cfg.get("eoc_special_token", SpecialTokens.eoc)
-
     # add all filters that produce stats
     if cfg.get("auto", False):
         cfg.process = load_ops_with_stats_meta()
@@ -693,6 +687,10 @@ def init_setup_from_cfg(cfg: Namespace, load_configs_only=False):
         "turbo": cfg.get("turbo", False),
         "skip_op_error": cfg.get("skip_op_error", True),
         "work_dir": cfg.work_dir,
+        "image_special_token": cfg.get("image_special_token", SpecialTokens.image),
+        "audio_special_token": cfg.get("audio_special_token", SpecialTokens.audio),
+        "video_special_token": cfg.get("video_special_token", SpecialTokens.video),
+        "eoc_special_token": cfg.get("eoc_special_token", SpecialTokens.eoc),
     }
     cfg.process = update_op_attr(cfg.process, op_attrs)
 

--- a/data_juicer/ops/base_op.py
+++ b/data_juicer/ops/base_op.py
@@ -7,7 +7,7 @@ from loguru import logger
 
 from data_juicer import is_cuda_available
 from data_juicer.utils.constant import Fields
-from data_juicer.utils.mm_utils import size_to_bytes
+from data_juicer.utils.mm_utils import SpecialTokens, size_to_bytes
 from data_juicer.utils.model_utils import free_models
 from data_juicer.utils.process_utils import calculate_np
 from data_juicer.utils.registry import Registry
@@ -195,6 +195,11 @@ class OP:
             self.mem_required = size_to_bytes(self.mem_required) / 1024**3
 
         self.turbo = kwargs.get("turbo", False)
+        # update special tokens
+        SpecialTokens.image = kwargs.get("image_special_token", SpecialTokens.image)
+        SpecialTokens.audio = kwargs.get("audio_special_token", SpecialTokens.audio)
+        SpecialTokens.video = kwargs.get("video_special_token", SpecialTokens.video)
+        SpecialTokens.eoc = kwargs.get("eoc_special_token", SpecialTokens.eoc)
 
         # nested wrappers
         from data_juicer.core.data import wrap_func_with_nested_access


### PR DESCRIPTION
This PR moves the special token setup from `init_setup_from_cfg` to `base_op`.
This change addresses the multi-process compatibility issue discussed in #682.