### PR TITLE
Fix Ray connection error by passing cfg parameter through resource utility functions

### DIFF
--- a/data_juicer/config/config.py
+++ b/data_juicer/config/config.py
@@ -674,7 +674,7 @@ def init_setup_from_cfg(cfg: Namespace, load_configs_only=False):
     # check number of processes np
     from data_juicer.utils.resource_utils import cpu_count
 
-    sys_cpu_count = cpu_count()
+    sys_cpu_count = cpu_count(cfg)
     if cfg.get("np", None) and cfg.np > sys_cpu_count:
         logger.warning(
             f"Number of processes `np` is set as [{cfg.np}], which "

--- a/data_juicer/utils/resource_utils.py
+++ b/data_juicer/utils/resource_utils.py
@@ -63,10 +63,10 @@ def query_mem_info(query_key):
     return val
 
 
-def _cuda_device_count():
+def _cuda_device_count(cfg=None):
     _torch_available = _is_package_available("torch")
 
-    if check_and_initialize_ray():
+    if check_and_initialize_ray(cfg):
         return int(ray_gpu_count())
 
     if _torch_available:
@@ -88,32 +88,32 @@ def _cuda_device_count():
         return 0
 
 
-def cuda_device_count():
-    return _cuda_device_count()
+def cuda_device_count(cfg=None):
+    return _cuda_device_count(cfg)
 
 
 def is_cuda_available():
     return cuda_device_count() > 0
 
 
-def cpu_count():
-    if check_and_initialize_ray():
+def cpu_count(cfg=None):
+    if check_and_initialize_ray(cfg):
         return int(ray_cpu_count())
 
     return psutil.cpu_count()
 
 
-def available_memories() -> List[int]:
+def available_memories(cfg=None) -> List[int]:
     """Available memory for each node in MB."""
-    if check_and_initialize_ray():
+    if check_and_initialize_ray(cfg):
         return ray_available_memories()
 
     return [int(psutil.virtual_memory().available / (1024**2))]
 
 
-def available_gpu_memories() -> List[int]:
+def available_gpu_memories(cfg=None) -> List[int]:
     """Available gpu memory of each gpu card for each alive node in MB."""
-    if check_and_initialize_ray():
+    if check_and_initialize_ray(cfg):
         return ray_available_gpu_memories()
 
     try:


### PR DESCRIPTION
This PR fixes a critical bug that prevents Data-Juicer from connecting to remote Ray clusters when using the Ray executor.

issuse: #807 

## Problem

  When users configure a remote Ray cluster in their config file (e.g., ray_address: 'ray://host:port'), the system fails to connect and throws a ConnectionError.
  Investigation revealed that the cfg parameter was not being passed through the resource utility function call chain during initialization, causing Ray to default to
  address='auto' instead of using the configured remote address.
