### PR TITLE
[HOT FIX] Fix Sphinx autodoc compatibility in SpecialTokens metaclass

### DIFF
--- a/data_juicer/utils/mm_utils.py
+++ b/data_juicer/utils/mm_utils.py
@@ -49,6 +49,8 @@ class _MetaSpecialTokens(type):
             env_var = f"{SPECIAL_TOKEN_ENV_PREFIX}{name.upper()}"
             os.environ[env_var] = value
             super().__setattr__(name, value)
+        elif name.startswith("__") and name.endswith("__"):
+            super().__setattr__(name, value)
         else:
             raise ValueError(
                 f"{name} is not a valid special token name, "


### PR DESCRIPTION
Problem:
Sphinx autodoc fails when processing `SpecialTokens` class due to overly restrictive `__setattr__` in `_MetaSpecialTokens` metaclass that blocks `__annotations__` attribute setting.

Changes: 
Allow Python system attributes (`__*__`) to be set normally
