### PR TITLE
fix: exclude __dj_stats__ column when comparing datasets in trace_filter

### DIFF
--- a/data_juicer/core/tracer.py
+++ b/data_juicer/core/tracer.py
@@ -155,8 +155,12 @@ class Tracer:
         # number of found filtered samples. It's the offset between two
         # datasets as well.
         num = 0
-        previous_ds_no_stats = previous_ds.remove_columns(Fields.stats)
-        processed_ds_no_stats = processed_ds.remove_columns(Fields.stats)
+        previous_ds_no_stats = (
+            previous_ds.remove_columns(Fields.stats) if Fields.stats in previous_ds.column_names else previous_ds
+        )
+        processed_ds_no_stats = (
+            processed_ds.remove_columns(Fields.stats) if Fields.stats in processed_ds.column_names else processed_ds
+        )
         while i < len(previous_ds):
             if i - num >= len(processed_ds) or previous_ds_no_stats[i] != processed_ds_no_stats[i - num]:
                 # 1. If all samples in processed dataset are checked but there


### PR DESCRIPTION
The `trace_filter` method was incorrectly comparing datasets because it included the `__dj_stats__` column. This column gets populated during processing, causing `previous_ds[i] != processed_ds[i - num]` to always be True (unless the stats column already existed in the previous dataset).

This made the filter detection logic fail, as it couldn't properly identify which samples were actually filtered.

So I remove the `__dj_stats__` column before comparison, while preserving it in the output results.

Fixes #821