### PR TITLE
Fixes the issue where `export_aws_credentials` cannot be read proper…

### DIFF
--- a/data_juicer/core/executor/ray_executor.py
+++ b/data_juicer/core/executor/ray_executor.py
@@ -82,16 +82,16 @@ class RayExecutor(ExecutorBase):
             # The RayExporter will handle falling back to environment variables or other credential mechanisms.
             if hasattr(self.cfg, "export_aws_credentials") and self.cfg.export_aws_credentials:
                 export_aws_creds = self.cfg.export_aws_credentials
-                if hasattr(export_aws_creds, "aws_access_key_id"):
-                    export_extra_args["aws_access_key_id"] = export_aws_creds.aws_access_key_id
-                if hasattr(export_aws_creds, "aws_secret_access_key"):
-                    export_extra_args["aws_secret_access_key"] = export_aws_creds.aws_secret_access_key
-                if hasattr(export_aws_creds, "aws_session_token"):
-                    export_extra_args["aws_session_token"] = export_aws_creds.aws_session_token
-                if hasattr(export_aws_creds, "aws_region"):
-                    export_extra_args["aws_region"] = export_aws_creds.aws_region
-                if hasattr(export_aws_creds, "endpoint_url"):
-                    export_extra_args["endpoint_url"] = export_aws_creds.endpoint_url
+                # Iterate through the required fields directly, and copy them to export_extra_args if they exist.
+                credential_fields = {
+                    "aws_access_key_id",
+                    "aws_secret_access_key",
+                    "aws_session_token",
+                    "aws_region",
+                    "endpoint_url",
+                }
+                for field in credential_fields.intersection(export_aws_creds):
+                    export_extra_args[field] = export_aws_creds[field]
 
         self.exporter = RayExporter(
             self.cfg.export_path,


### PR DESCRIPTION
  Fixes the issue where `export_aws_credentials` cannot be read properly in RayExecutor when using S3 export paths.

  Fixes #833 

  ## Problem

  The code in `ray_executor.py` was using object attribute access (`hasattr()` and `.attribute`) to read `export_aws_credentials`, but this field is defined as `type=Dict` in the config parser, which
  means it's a Python dictionary, not a Namespace object.

  This type mismatch caused the credentials to never be read from the config file, forcing users to rely on environment variables or experiencing S3 export failures.

  ## Changes

  Modified `data_juicer/core/executor/ray_executor.py` (lines 85-94):
  - Replaced object-style attribute checks (`hasattr()`) with dictionary-style key checks (`in`)
  - Changed from individual `if` statements to a cleaner loop-based approach
  - Improved code maintainability and Pythonic style

  **Before:**
  ```python
  if hasattr(export_aws_creds, "aws_access_key_id"):
      export_extra_args["aws_access_key_id"] = export_aws_creds.aws_access_key_id
  if hasattr(export_aws_creds, "aws_secret_access_key"):
      export_extra_args["aws_secret_access_key"] = export_aws_creds.aws_secret_access_key
  if hasattr(export_aws_creds, "aws_session_token"):
      export_extra_args["aws_session_token"] = export_aws_creds.aws_session_token
  if hasattr(export_aws_creds, "aws_region"):
      export_extra_args["aws_region"] = export_aws_creds.aws_region
  if hasattr(export_aws_creds, "endpoint_url"):
      export_extra_args["endpoint_url"] = export_aws_creds.endpoint_url
```
  **After:**
  ```python
    credential_fields = {
        "aws_access_key_id",
        "aws_secret_access_key",
        "aws_session_token",
        "aws_region",
        "endpoint_url"
    }
    for field in credential_fields.intersection(export_aws_creds):
        export_extra_args[field] = export_aws_creds[field]
```