### PR TITLE
Refine and merge for PR568

### DIFF
--- a/tools/distributed_deduplication/dedup_utils.py
+++ b/tools/distributed_deduplication/dedup_utils.py
@@ -5,7 +5,7 @@
 from typing import List, Optional, Tuple
 
 from loguru import logger
-from pyspark import SparkConf
+from pyspark import SparkConf, StorageLevel
 from pyspark.sql import SparkSession
 
 
@@ -93,10 +93,20 @@ def find_components(edges):
 
     a = edges
     while True:
-        b = a.flatMap(large_star_map).groupByKey().flatMap(
-            large_star_reduce).distinct()
-        a = b.map(small_star_map).groupByKey().flatMap(
-            small_star_reduce).distinct()
+        b = (
+            a.flatMap(large_star_map)
+            .groupByKey()
+            .flatMap(large_star_reduce)
+            .distinct()
+            .persist(StorageLevel.MEMORY_AND_DISK)
+        )
+        a = (
+            b.map(small_star_map)
+            .groupByKey()
+            .flatMap(small_star_reduce)
+            .distinct()
+            .persist(StorageLevel.MEMORY_AND_DISK)
+        )
         changes = a.subtract(b).union(b.subtract(a)).count()
         if changes == 0:
             break


### PR DESCRIPTION
As the title says.

Use `persist(StorageLevel.MEMORY_AND_DISK)` instead of default MEMORY_ONLY and none in the PR to balance between memory and computing speed.