### PR TITLE
fix: optimize Ray pipeline performance with column caching and lazy actor initialization

### DIFF
--- a/data_juicer/ops/deduplicator/ray_basic_deduplicator.py
+++ b/data_juicer/ops/deduplicator/ray_basic_deduplicator.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-
+from typing import Union
 from data_juicer.utils.constant import HashKeys
 from data_juicer.utils.lazy_loader import LazyLoader
 
@@ -45,17 +45,38 @@ class Backend(ABC):
 class ActorBackend(Backend):
     """
     Ray actor backend for deduplicator.
+    Uses lazy initialization to defer actor creation until first use,
+    allowing the cluster to autoscale before actors consume resources.
     """
 
-    def __init__(self, dedup_set_num: int, RemoteDedupSet=None):
-        self.dedup_set_num = dedup_set_num
-        if RemoteDedupSet is None:
-            RemoteDedupSet = get_remote_dedup_set()
-        self.dedup_sets = [RemoteDedupSet.remote() for _ in range(self.dedup_set_num)]
+    def __init__(self, dedup_set_num: Union[int, str], RemoteDedupSet=None):
+        # Store config but don't create actors yet
+        # dedup_set_num can be int or "auto"
+        self._dedup_set_num_config = dedup_set_num
+        self._RemoteDedupSet = RemoteDedupSet
+        self._dedup_sets = None  # Lazy - created on first use
+        self._actual_dedup_set_num = None
+
+    @property
+    def dedup_set_num(self):
+        """Get actual dedup_set_num, calculating from cluster resources if 'auto'."""
+        if self._actual_dedup_set_num is None:
+            if self._dedup_set_num_config == "auto":
+                self._actual_dedup_set_num = max(1, int(ray.cluster_resources().get("CPU", 1) / 2))
+            else:
+                self._actual_dedup_set_num = int(self._dedup_set_num_config)
+        return self._actual_dedup_set_num
+
+    def _ensure_actors(self):
+        """Create actors on first use when cluster has scaled."""
+        if self._dedup_sets is None:
+            RemoteDedupSet = self._RemoteDedupSet or get_remote_dedup_set()
+            self._dedup_sets = [RemoteDedupSet.remote() for _ in range(self.dedup_set_num)]
 
     def is_unique(self, md5_value: str):
+        self._ensure_actors()
         dedup_set_id = int.from_bytes(md5_value.encode(), byteorder="little") % MERSENNE_PRIME % self.dedup_set_num
-        return ray.get(self.dedup_sets[dedup_set_id].is_unique.remote(md5_value))
+        return ray.get(self._dedup_sets[dedup_set_id].is_unique.remote(md5_value))
 
 
 class RedisBackend(Backend):
@@ -82,11 +103,19 @@ class RayBasicDeduplicator(Filter):
     # TODO: Set a more reasonable value
     EMPTY_HASH_VALUE = "EMPTY"
 
-    def __init__(self, backend: str = "ray_actor", redis_address: str = "redis://localhost:6379", *args, **kwargs):
+    def __init__(
+        self,
+        backend: str = "ray_actor",
+        redis_address: str = "redis://localhost:6379",
+        dedup_set_num: Union[int, str] = "auto",
+        *args,
+        **kwargs,
+    ):
         """
         Initialization.
         :param backend: the backend for dedup, either 'ray_actor' or 'redis'
         :param redis_address: the address of redis server
+        :param dedup_set_num: number of dedup set actors, or 'auto' to use CPU/2
         :param args: extra args
         :param kwargs: extra args
         """
@@ -94,7 +123,7 @@ class RayBasicDeduplicator(Filter):
         self.redis_address = redis_address
         self.backend = backend
         if backend == "ray_actor":
-            dedup_set_num = int(ray.cluster_resources().get("CPU") / 2)
+            # Pass dedup_set_num directly - ActorBackend handles "auto" lazily
             self.backend = ActorBackend(dedup_set_num)
         elif backend == "redis":
             # TODO: add a barrier to ensure that flushdb is performed before

--- a/data_juicer/ops/deduplicator/ray_document_deduplicator.py
+++ b/data_juicer/ops/deduplicator/ray_document_deduplicator.py
@@ -1,6 +1,6 @@
 import hashlib
 import string
-
+from typing import Union
 import regex as re
 
 from ..base_op import OPERATORS
@@ -26,6 +26,7 @@ class RayDocumentDeduplicator(RayBasicDeduplicator):
         self,
         backend: str = "ray_actor",
         redis_address: str = "redis://localhost:6379",
+        dedup_set_num: Union[int, str] = "auto",
         lowercase: bool = False,
         ignore_non_character: bool = False,
         *args,
@@ -35,13 +36,20 @@ class RayDocumentDeduplicator(RayBasicDeduplicator):
         Initialization method.
         :param backend: the backend for dedup, either 'ray_actor' or 'redis'
         :param redis_address: the address of redis server
+        :param dedup_set_num: number of dedup set actors, or 'auto' to use CPU/2
         :param lowercase: Whether to convert sample text to lower case
         :param ignore_non_character: Whether to ignore non-alphabet
         characters, including whitespaces, digits, and punctuations
         :param args: extra args
         :param kwargs: extra args.
         """
-        super().__init__(backend=backend, redis_address=redis_address, *args, **kwargs)
+        super().__init__(
+            backend=backend,
+            redis_address=redis_address,
+            dedup_set_num=dedup_set_num,
+            *args,
+            **kwargs,
+        )
         self.lowercase = lowercase
         self.remove_non_character_regex = (
             re.compile(f"\s+|\d+|[{re.escape(string.punctuation)}]") if ignore_non_character else None  # noqa: W605

--- a/data_juicer/utils/ray_utils.py
+++ b/data_juicer/utils/ray_utils.py
@@ -104,7 +104,7 @@ def get_ray_nodes_info(cfg=None):
         node_id = node["NodeID"]
         from ray.util import scheduling_strategies
 
-        strategy = scheduling_strategies.NodeAffinitySchedulingStrategy(node_id=node_id, soft=False)
+        strategy = scheduling_strategies.NodeAffinitySchedulingStrategy(node_id=node_id, soft=True)
         future = collect_node_info.options(scheduling_strategy=strategy).remote()
         futures.append(future)
 


### PR DESCRIPTION
## Summary

This PR addresses two key issues when running Data-Juicer with Ray:

1. **Pipeline breaking due to repeated `columns()` calls** - Ray's `Dataset.columns()` internally calls `limit(1)` which forces execution and can break streaming pipelines
2. **Premature actor creation before cluster autoscaling** - Deduplicator actors were created at `__init__` time, consuming resources before the cluster had time to scale up

## Changes

### Column Caching in Ray Dataset (`ray_dataset.py`)
- Cache dataset columns once at the start of `process()` and pass the cached set through the operator pipeline
- Update the cached set when new columns (`Fields.meta`, `Fields.stats`) are added
- Avoids repeated `self.data.columns()` calls that break streaming execution

### Lazy Actor Initialization in Deduplicators
- **`ray_basic_deduplicator.py`**: `ActorBackend` now defers actor creation until first use via `_ensure_actors()`
- **`ray_bts_minhash_deduplicator.py`**: Union-find actors and edge buffers are created lazily in `_ensure_actors()`, called at the start of `run()`
- **`ray_document_deduplicator.py`**: Pass through the new `dedup_set_num` parameter

### Auto-scaling Support
- Added `dedup_set_num="auto"` parameter (default) that calculates optimal actor count from cluster CPU resources (`CPU/2`, minimum 1)
- Calculation happens at actor creation time when cluster has scaled, not at `__init__` time

### Scheduling Strategy (`ray_utils.py`)
- Changed `NodeAffinitySchedulingStrategy` from `soft=False` to `soft=True` to reduce scheduling failures when target nodes are temporarily unavailable

## Testing
- Tested with large-scale FineWeb data processing on Anyscale with autoscaling worker nodes

## Breaking Changes
None - all changes are backward compatible. The `dedup_set_num` parameter defaults to `"auto"` which preserves the previous behavior of using `CPU/2`.