### PR TITLE
feat(api): add OpenAI Responses API support

### DIFF
--- a/data_juicer/utils/model_utils.py
+++ b/data_juicer/utils/model_utils.py
@@ -236,7 +236,7 @@ class ChatAPIModel:
                 self.endpoint, body=body, cast_to=httpx.Response, stream=stream, stream_cls=stream_cls
             )
             result = response.json()
-            return nested_access(result, self.response_path)
+            return nested_access(result, self.response_path) or ""
         except Exception as e:
             logger.exception(e)
             return ""
@@ -332,7 +332,7 @@ class ResponsesAPIModel:
         try:
             response = self._client.post(self.endpoint, body=body, cast_to=httpx.Response)
             result = response.json()
-            return nested_access(result, self.response_path)
+            return nested_access(result, self.response_path) or ""
         except Exception as e:
             logger.exception(f"Responses API error: {e}")
             return ""

--- a/tests/utils/test_model_utils.py
+++ b/tests/utils/test_model_utils.py
@@ -119,11 +119,23 @@ class ModelUtilsTest(DataJuicerTestCaseBase):
         self.assertEqual(processor, mock_processor)
         mock_tiktoken.encoding_for_model.assert_called_with('text_embedding_model')
 
+        # Test responses endpoint with default response path
+        mock_openai.OpenAI.reset_mock()
+        responses_model = prepare_api_model('test_model', endpoint='/responses')
+        self.assertEqual(responses_model.endpoint, '/responses')
+        self.assertEqual(responses_model.response_path, 'output.0.content.0.text')
+
+        # Test responses endpoint with different casing
+        mock_openai.OpenAI.reset_mock()
+        responses_model = prepare_api_model('test_model', endpoint='/api/RESPONSES/v1')
+        self.assertEqual(responses_model.endpoint, '/api/RESPONSES/v1')
+        self.assertEqual(responses_model.response_path, 'output.0.content.0.text')
+
         # Test unsupported endpoint
         with self.assertRaises(ValueError) as context:
             prepare_api_model('test_model', endpoint='/unsupported/endpoint')
         self.assertIn('Unsupported endpoint', str(context.exception))
-        
+
     @patch('data_juicer.utils.model_utils.transformers')
     def test_prepare_huggingface_model(self, mock_transformers):
         # Test model with processor


### PR DESCRIPTION
## Summary

Add support for OpenAI's [Responses API](https://platform.openai.com/docs/api-reference/responses) (`/responses` endpoint) by introducing a new `ResponsesAPIModel` class, following the existing pattern of `ChatAPIModel` and `EmbeddingAPIModel`.

## Changes

- **`data_juicer/utils/model_utils.py`**
  - Add `ResponsesAPIModel` class with default endpoint `/responses` and response path `output.0.content.0.text`
  - Register `"responses"` in `ENDPOINT_CLASS_MAP` within `prepare_api_model()`
  - Update docstring to document the new endpoint option
  - Add `or ""` fallback to `nested_access` in both `ChatAPIModel` and `ResponsesAPIModel` for consistent error handling

- **`tests/utils/test_model_utils.py`**
  - Extend `test_prepare_api_model` to cover the responses endpoint (default values, case-insensitive matching)

## Use Cases

The Responses API offers several advantages over the Chat Completions API that could benefit Data Juicer OPs:

- **Reasoning models** - Native support for models like `gpt-5-mini` with configurable `reasoning={"effort": "low|medium|high"}`
- **Built-in tool use** - Simplified function calling without manually managing tool schemas in messages
- **Stateful conversations** - `previous_response_id` enables multi-turn context without resending full history
- **Simpler interface** - Uses `input` string instead of `messages` array, reducing boilerplate for single-turn tasks

## Usage

```python
from data_juicer.utils.model_utils import prepare_api_model

model = prepare_api_model(
    "gpt-5-mini",
    endpoint="/responses",
    response_path="output.1.content.0.text",  # reasoning models have different structure
)
response = model(
    "What is 2+2?",
    instructions="Respond concisely.",  # Responses API parameter
    reasoning={"effort": "low"},         # Responses API parameter
)
print(response)
# '2 + 2 = 4.'
```
