### PR TITLE
fix: reduce import timing log noise by using debug level

### DIFF
--- a/data_juicer/ops/__init__.py
+++ b/data_juicer/ops/__init__.py
@@ -9,7 +9,7 @@ def timing_context(description):
     start_time = time.time()
     yield
     elapsed_time = time.time() - start_time
-    logger.info(f"{description} took {elapsed_time:.2f} seconds")
+    logger.debug(f"{description} took {elapsed_time:.2f} seconds")
 
 
 # yapf: disable


### PR DESCRIPTION
Changed `logger.info` to `logger.debug` in `timing_context` so import timing is only visible when debug logging is enabled.