### PR TITLE
fix: check meta and stats schema before op iter, avoid data.columns()

### DIFF
--- a/data_juicer/core/data/ray_dataset.py
+++ b/data_juicer/core/data/ray_dataset.py
@@ -151,12 +151,12 @@ class RayDataset(DJDataset):
 
         calculate_ray_np(operators)
 
-        self._ensure_schemas(operators)
+        self._prepare_schemas(operators)
         for op in operators:
             self._run_single_op(op)
         return self
 
-    def _ensure_schemas(self, operators):
+    def _prepare_schemas(self, operators):
         current_columns = self.data.columns()
         if Fields.stats not in current_columns:
             if any(isinstance(op, Filter) for op in operators):


### PR DESCRIPTION
Calling `data.columns()` inside the loop caused the data block DAG to execute repeatedly, which negatively affected the actor status. 

This change moves the schema check outside the iteration loop. A potential issue remains: if an operator internally removes meta or stats fields, the pre-loop check will not detect this modification, which could lead to runtime errors. Adding checks inside the func may negatively impact performance.

Other improvements could be implemented (ordered by complexity and thoroughness):

1. Executor Validation: Add a mechanism similar to validate_process_order in the executor. This would detect risks of deduplication state pollution and raise an error, prompting the user to adjust the operator order.

2. Side-effect-free Inference: Enable stateful operators to support side-effect-free schema inference. For example, introducing a self._in_schema_infer flag to skip sensitive logic (such as deduplication) during inference.

3. Base Class Modification: Modify the filter base class to handle delayed .columns() triggering. However, this has a large blast radius and risks breaking the correctness of other operators.