### PR TITLE
feat: add memory reservation parameters for Ray minhash deduplication

### DIFF
--- a/data_juicer/ops/deduplicator/ray_bts_minhash_deduplicator.py
+++ b/data_juicer/ops/deduplicator/ray_bts_minhash_deduplicator.py
@@ -550,7 +550,10 @@ class RayBTSMinhashDeduplicator(Deduplicator):
         ]
 
         # Wait for all actors to be ready before proceeding
-        ray.get([uf.__ray_ready__.remote() for uf in self.union_find_list] + [eb.__ray_ready__.remote() for eb in self.remote_edge_buffers])
+        ray.get(
+            [uf.__ray_ready__.remote() for uf in self.union_find_list]
+            + [eb.__ray_ready__.remote() for eb in self.remote_edge_buffers]
+        )
 
         empty_hash_value = np.full((self.num_rows_per_band,), MAX_HASH, dtype=np.uint32)
         self.empty_hash_value = b"\x00\x00\x00\x00" + empty_hash_value.tobytes()


### PR DESCRIPTION
## Summary
- Add `actor_memory` parameter for EdgeBuffer/BTSUnionFind actors (bytes)
- Add `task_memory` parameter for map_batches tasks (bytes)
- Add actor readiness check before processing
- Refactor map_batches calls to use kwargs dict pattern

## Background
For billion-row scale deduplication, memory pressure can cause OOM issues. These parameters allow users to reserve memory for actors and tasks:

```python
ray_bts_minhash_deduplicator:
  actor_memory: 20_000_000_000  # 20GB per actor
  task_memory: 2_000_000_000    # 2GB per task
```

## Test plan
- [ ] Test with existing dedup configs (no memory params - backward compatible)
- [ ] Test with memory params on large-scale data