### PR TITLE
fix: use consistent key naming in tracer output

### DIFF
--- a/data_juicer/core/tracer.py
+++ b/data_juicer/core/tracer.py
@@ -65,7 +65,7 @@ class Tracer:
             if previous_sample != processed_sample:
                 dif_dict.append(
                     {
-                        "original text": previous_sample,
+                        "original_text": previous_sample,
                         "processed_text": processed_sample,
                     }
                 )

--- a/tests/core/test_tracer.py
+++ b/tests/core/test_tracer.py
@@ -30,7 +30,7 @@ class TracerTest(DataJuicerTestCaseBase):
         ])
         dif_list = [
             {
-                'original text': 'text 2',
+                'original_text': 'text 2',
                 'processed_text': 'processed text 2',
             }
         ]
@@ -57,7 +57,7 @@ class TracerTest(DataJuicerTestCaseBase):
         ])
         dif_list = [
             {
-                'original text': 'text 2',
+                'original_text': 'text 2',
                 'processed_text': 'processed text 2',
             }
         ]


### PR DESCRIPTION
## Summary

The `trace_mapper()` method in `Tracer` outputs a JSONL file with inconsistent key naming:

- `original text` (with a space)
- `processed_text` (with an underscore)

This PR fixes the inconsistency by changing `original text` to `original_text`, making both keys use snake_case.

```diff
# Before fix
- {"original text": "Hello friend", "processed_text": "Ahoy matey"}
# After fix
+ {"original_text": "Hello friend", "processed_text": "Ahoy matey"}
```