### PR TITLE
fix: add thread limiting for multi-process workloads to prevent over-subscription

### DIFF
--- a/data_juicer/utils/process_utils.py
+++ b/data_juicer/utils/process_utils.py
@@ -41,6 +41,7 @@ def setup_worker_threads(num_threads=1):
     # Set PyTorch thread limits directly (works even after torch is imported)
     try:
         import torch
+
         torch.set_num_threads(num_threads)
         torch.set_num_interop_threads(num_threads)
         logger.debug(f"Set torch threads to {num_threads}")

--- a/tests/utils/test_model_utils.py
+++ b/tests/utils/test_model_utils.py
@@ -119,11 +119,23 @@ class ModelUtilsTest(DataJuicerTestCaseBase):
         self.assertEqual(processor, mock_processor)
         mock_tiktoken.encoding_for_model.assert_called_with('text_embedding_model')
 
+        # Test responses endpoint with default response path
+        mock_openai.OpenAI.reset_mock()
+        responses_model = prepare_api_model('test_model', endpoint='/responses')
+        self.assertEqual(responses_model.endpoint, '/responses')
+        self.assertEqual(responses_model.response_path, 'output.0.content.0.text')
+
+        # Test responses endpoint with different casing
+        mock_openai.OpenAI.reset_mock()
+        responses_model = prepare_api_model('test_model', endpoint='/api/RESPONSES/v1')
+        self.assertEqual(responses_model.endpoint, '/api/RESPONSES/v1')
+        self.assertEqual(responses_model.response_path, 'output.0.content.0.text')
+
         # Test unsupported endpoint
         with self.assertRaises(ValueError) as context:
             prepare_api_model('test_model', endpoint='/unsupported/endpoint')
         self.assertIn('Unsupported endpoint', str(context.exception))
-        
+
     @patch('data_juicer.utils.model_utils.transformers')
     def test_prepare_huggingface_model(self, mock_transformers):
         # Test model with processor


### PR DESCRIPTION
**Summary**
Fixes severe performance degradation when running operators with CLIP-based models (e.g., `image_aesthetics_filter`, `image_text_similarity_filter`) with `num_proc > 1` with **CPU-only** by limiting PyTorch threads in worker processes.

**Problem**: When multiple worker processes are spawned, each worker defaults to using all CPU cores for PyTorch operations. This causes thread over-subscription (e.g., 3 workers × 8 threads = 24 threads competing for 8 cores), leading to massive context switching overhead and cache thrashing.

**Solution**: Call `torch.set_num_threads(1)` and `torch.set_num_interop_threads(1)` in worker processes when loading models, ensuring each worker uses only `1` thread.

**Changes**:

  - Add `setup_worker_threads()` utility function in process_utils.py
  - Call it from `get_model()` in `model_utils.py` for non-main processes

Test with num_proc=3, should complete in seconds instead of minutes with 8-core CPU

```
from data_juicer.core.data import NestedDataset as Dataset
from data_juicer.ops.filter.image_aesthetics_filter import ImageAestheticsFilter
from data_juicer.utils.constant import Fields

dataset = Dataset.from_list([{"images": ["tests/ops/data/img1.png"]}] * 10)
dataset = dataset.add_column(name=Fields.stats, column=[{}] * dataset.num_rows)

op = ImageAestheticsFilter()
dataset = dataset.map(op.compute_stats, num_proc=3)
```