### PR TITLE
build: add JUICER_API_URL env var in docs deploy workflow

### DIFF
--- a/.github/workflows/deploy_sphinx_docs.yml
+++ b/.github/workflows/deploy_sphinx_docs.yml
@@ -22,6 +22,7 @@ jobs:
       PROJECT: ${{ github.event.repository.name }}
       REPO_OWNER: ${{ github.repository_owner }}
       MIN_TAG: v1.4.0
+      JUICER_API_URL: ${{ vars.JUICER_API_URL }}
     steps:
       - name: Mount /mnt into workspace (writable)
         run: |


### PR DESCRIPTION
As the title says.

For the ai widget of the homepage. 

Requires syncing the repository variables (already configured).