### PR TITLE
 fix: convert string type names to Python types in RequiredFieldsValidator (#796)

### DIFF
--- a/data_juicer/core/data/data_validator.py
+++ b/data_juicer/core/data/data_validator.py
@@ -255,18 +255,18 @@ class RequiredFieldsValidator(DataValidator):
 
     # Mapping from type name strings to actual Python types
     TYPE_NAME_MAPPING: Dict[str, type] = {
-        'str': str,
-        'string': str,
-        'int': int,
-        'integer': int,
-        'float': float,
-        'bool': bool,
-        'boolean': bool,
-        'list': list,
-        'dict': dict,
-        'tuple': tuple,
-        'set': set,
-        'bytes': bytes,
+        "str": str,
+        "string": str,
+        "int": int,
+        "integer": int,
+        "float": float,
+        "bool": bool,
+        "boolean": bool,
+        "list": list,
+        "dict": dict,
+        "tuple": tuple,
+        "set": set,
+        "bytes": bytes,
     }
 
     def __init__(self, config: Dict):
@@ -283,13 +283,12 @@ class RequiredFieldsValidator(DataValidator):
         super().__init__(config)
 
         self.required_fields = config["required_fields"]
-        self.field_types = self._normalize_field_types(
-            config.get("field_types", {}))
+        self.field_types = self._normalize_field_types(config.get("field_types", {}))
         # Default no missing allowed
         self.allow_missing = config.get("allow_missing", 0.0)
         self.sample_size = config.get("sample_size", 100)
 
-    def _normalize_field_types(self, field_types: Dict) -> Dict[str, type]:
+    def _normalize_field_types(self, field_types: Dict[str, object]) -> Dict[str, type]:
         """
         Convert field type specifications to actual Python type objects.
 
@@ -310,10 +309,9 @@ class RequiredFieldsValidator(DataValidator):
             elif isinstance(type_spec, str):
                 type_name = type_spec.lower()
                 if type_name not in self.TYPE_NAME_MAPPING:
+                    supported_types = ", ".join(sorted(self.TYPE_NAME_MAPPING.keys()))
                     raise DataValidationError(
-                        f"Unknown type name '{type_spec}' for field "
-                        f"'{field}'. Supported types: "
-                        f"{list(self.TYPE_NAME_MAPPING.keys())}"
+                        f"Unknown type name '{type_spec}' for field " f"'{field}'. Supported types: {supported_types}"
                     )
                 normalized[field] = self.TYPE_NAME_MAPPING[type_name]
             else:

--- a/tests/core/data/test_data_validator.py
+++ b/tests/core/data/test_data_validator.py
@@ -1,44 +1,30 @@
 from unittest import main
+
 import datasets
-from data_juicer.utils.unittest_utils import DataJuicerTestCaseBase, TEST_TAG
+
 from data_juicer.core.data import NestedDataset
 from data_juicer.core.data.data_validator import (
-    DataValidationError, 
+    DataJuicerFormatValidator,
+    DataValidationError,
+    DataValidatorRegistry,
     RequiredFieldsValidator,
     SwiftMessagesValidator,
-    DataJuicerFormatValidator,
-    DataValidatorRegistry
 )
+from data_juicer.utils.unittest_utils import TEST_TAG, DataJuicerTestCaseBase
 
 
 # Test RequiredFieldsValidator
 class RequiredFieldsValidatorTest(DataJuicerTestCaseBase):
-    
+
     def setUp(self):
         super().setUp()
 
         # Create sample DataFrame
         self.data = [
-            {
-                'text': 'Hello',
-                'metadata': {'lang': 'en'},
-                'score': 1.0
-            },
-            {
-                'text': 'World',
-                'metadata': {'lang': 'es'},
-                'score': 2.0
-            },
-            {
-                'text': None,
-                'metadata': {'lang': 'fr'},
-                'score': 3.0
-            },
-            {
-                'text': 'Test',
-                'metadata': None,
-                'score': 4.0
-            }
+            {"text": "Hello", "metadata": {"lang": "en"}, "score": 1.0},
+            {"text": "World", "metadata": {"lang": "es"}, "score": 2.0},
+            {"text": None, "metadata": {"lang": "fr"}, "score": 3.0},
+            {"text": "Test", "metadata": None, "score": 4.0},
         ]
 
         # Create dataset
@@ -46,18 +32,14 @@ class RequiredFieldsValidatorTest(DataJuicerTestCaseBase):
 
     def test_basic_validation(self):
         """Test basic field validation"""
-        config = {
-            'type': 'required_fields',
-            'required_fields': ['text', 'metadata'],
-            'allow_missing': .25
-        }
-        validator = DataValidatorRegistry.get_validator(config['type'])(config)
-        
+        config = {"type": "required_fields", "required_fields": ["text", "metadata"], "allow_missing": 0.25}
+        validator = DataValidatorRegistry.get_validator(config["type"])(config)
+
         # Should pass
         validator.validate(self.dataset)
-        
+
         # Should fail with missing field
-        config['required_fields'].append('nonexistent')
+        config["required_fields"].append("nonexistent")
         validator = RequiredFieldsValidator(config)
         with self.assertRaises(DataValidationError) as exc:
             validator.validate(self.dataset)
@@ -67,18 +49,15 @@ class RequiredFieldsValidatorTest(DataJuicerTestCaseBase):
         """Test field type validation"""
         # Should pass
         config = {
-            'required_fields': ['text', 'score'],
-            'field_types': {
-                'text': str,
-                'score': float
-            },
-            'allow_missing': .25
+            "required_fields": ["text", "score"],
+            "field_types": {"text": str, "score": float},
+            "allow_missing": 0.25,
         }
         validator = RequiredFieldsValidator(config)
         validator.validate(self.dataset)
 
         # Should fail with wrong type
-        config['field_types']['score'] = str
+        config["field_types"]["score"] = str
         validator = RequiredFieldsValidator(config)
         with self.assertRaises(DataValidationError) as exc:
             validator.validate(self.dataset)
@@ -88,30 +67,24 @@ class RequiredFieldsValidatorTest(DataJuicerTestCaseBase):
         """Test field type validation with string type names (from YAML config)"""
         # Should pass with string type names
         config = {
-            'required_fields': ['text', 'score'],
-            'field_types': {
-                'text': 'str',
-                'score': 'float'
-            },
-            'allow_missing': .25
+            "required_fields": ["text", "score"],
+            "field_types": {"text": "str", "score": "float"},
+            "allow_missing": 0.25,
         }
         validator = RequiredFieldsValidator(config)
         validator.validate(self.dataset)
 
         # Should also work with alternative type names
         config_alt = {
-            'required_fields': ['text', 'score'],
-            'field_types': {
-                'text': 'string',
-                'score': 'float'
-            },
-            'allow_missing': .25
+            "required_fields": ["text", "score"],
+            "field_types": {"text": "string", "score": "float"},
+            "allow_missing": 0.25,
         }
         validator_alt = RequiredFieldsValidator(config_alt)
         validator_alt.validate(self.dataset)
 
         # Should fail with wrong type (string specified)
-        config['field_types']['score'] = 'str'
+        config["field_types"]["score"] = "str"
         validator = RequiredFieldsValidator(config)
         with self.assertRaises(DataValidationError) as exc:
             validator.validate(self.dataset)
@@ -119,91 +92,70 @@ class RequiredFieldsValidatorTest(DataJuicerTestCaseBase):
 
     def test_type_validation_with_unknown_type_name(self):
         """Test that unknown type names raise an error"""
-        config = {
-            'required_fields': ['text'],
-            'field_types': {
-                'text': 'unknown_type'
-            }
-        }
+        config = {"required_fields": ["text"], "field_types": {"text": "unknown_type"}}
         with self.assertRaises(DataValidationError) as exc:
             RequiredFieldsValidator(config)
         self.assertIn("unknown type name", str(exc.exception).lower())
 
     def test_type_validation_with_invalid_type_spec(self):
         """Test that invalid type specifications raise an error"""
-        config = {
-            'required_fields': ['text'],
-            'field_types': {
-                'text': 123  # Neither a type nor a string
-            }
-        }
+        config = {"required_fields": ["text"], "field_types": {"text": 123}}  # Neither a type nor a string
         with self.assertRaises(DataValidationError) as exc:
             RequiredFieldsValidator(config)
         self.assertIn("invalid type specification", str(exc.exception).lower())
 
-    @TEST_TAG('ray')
+    @TEST_TAG("ray")
     def test_ray_dataset_support(self):
         import ray.data
+
         from data_juicer.core.data.ray_dataset import RayDataset
-        
+
         # Create ray dataset
         ray_dataset = RayDataset(ray.data.from_items(self.data))
 
         """Test validation with RayDataset"""
         config = {
-            'required_fields': ['text', 'metadata'],
-            'field_types': {
-                'text': str,
-                'metadata': dict
-            },
-            'allow_missing': .25
+            "required_fields": ["text", "metadata"],
+            "field_types": {"text": str, "metadata": dict},
+            "allow_missing": 0.25,
         }
         validator = RequiredFieldsValidator(config)
-        
+
         # Should pass
         validator.validate(ray_dataset)
 
     def test_invalid_dataset_type(self):
         """Test validation with unsupported dataset type"""
-        config = {
-            'required_fields': ['text']
-        }
+        config = {"required_fields": ["text"]}
         validator = RequiredFieldsValidator(config)
-        
+
         with self.assertRaises(DataValidationError) as exc:
             validator.validate([1, 2, 3])  # Invalid dataset type
         self.assertIn("unsupported dataset type", str(exc.exception).lower())
 
     def test_empty_required_fields(self):
         """Test validation with empty required fields"""
-        config = {
-            'required_fields': []
-        }
+        config = {"required_fields": []}
         validator = RequiredFieldsValidator(config)
-        
+
         # Should pass as no fields are required
         validator.validate(self.dataset)
 
-    @TEST_TAG('ray')
+    @TEST_TAG("ray")
     def test_multiple_dataset_types(self):
         import ray.data
+
         from data_juicer.core.data.ray_dataset import RayDataset
 
         # Create ray dataset
         ray_dataset = RayDataset(ray.data.from_items(self.data))
 
         """Test validation works with different dataset types"""
-        datasets_to_test = [
-            ('nested', self.dataset),
-            ('ray', ray_dataset)
-        ]
-        
-        config = {
-            'required_fields': ['text', 'metadata', 'score'],
-            'allow_missing': .25
-        }
+        datasets_to_test = [("nested", self.dataset), ("ray", ray_dataset)]
+
+        config = {"required_fields": ["text", "metadata", "score"], "allow_missing": 0.25}
         validator = RequiredFieldsValidator(config)
-        
+
         for name, dataset in datasets_to_test:
             with self.subTest(dataset_type=name):
                 validator.validate(dataset)
@@ -213,18 +165,18 @@ class TestSwiftMessagesValidator(DataJuicerTestCaseBase):
     def setUp(self):
         """Setup test validator"""
         super().setUp()
-        self.config = {'min_turns': 1, 'max_turns': 5}
+        self.config = {"min_turns": 1, "max_turns": 5}
         self.validator = SwiftMessagesValidator(self.config)
 
     def test_valid_conversation_with_system(self):
         """Test valid conversation with system message"""
         data = {
-            'messages': [
-                {'role': 'system', 'content': 'Be helpful'},
-                {'role': 'user', 'content': 'Hello'},
-                {'role': 'assistant', 'content': 'Hi there'},
-                {'role': 'user', 'content': 'How are you?'},
-                {'role': 'assistant', 'content': 'I am good!'}
+            "messages": [
+                {"role": "system", "content": "Be helpful"},
+                {"role": "user", "content": "Hello"},
+                {"role": "assistant", "content": "Hi there"},
+                {"role": "user", "content": "How are you?"},
+                {"role": "assistant", "content": "I am good!"},
             ]
         }
         dataset = NestedDataset(datasets.Dataset.from_list([data]))
@@ -232,18 +184,13 @@ class TestSwiftMessagesValidator(DataJuicerTestCaseBase):
 
     def test_valid_conversation_without_system(self):
         """Test valid conversation without system message"""
-        data = {
-            'messages': [
-                {'role': 'user', 'content': 'Hello'},
-                {'role': 'assistant', 'content': 'Hi there'}
-            ]
-        }
+        data = {"messages": [{"role": "user", "content": "Hello"}, {"role": "assistant", "content": "Hi there"}]}
         dataset = NestedDataset(datasets.Dataset.from_list([data]))
         self.validator.validate(dataset)  # Should not raise
 
     def test_missing_messages(self):
         """Test conversation with missing messages field"""
-        data = {'random': 'random_value'}
+        data = {"random": "random_value"}
         dataset = NestedDataset(datasets.Dataset.from_list([data]))
         with self.assertRaises(DataValidationError) as exc:
             self.validator.validate(dataset)
@@ -251,7 +198,7 @@ class TestSwiftMessagesValidator(DataJuicerTestCaseBase):
 
     def test_invalid_messages_type(self):
         """Test conversation with non-array messages"""
-        data = {'messages': 'not an array'}
+        data = {"messages": "not an array"}
         dataset = NestedDataset(datasets.Dataset.from_list([data]))
         with self.assertRaises(DataValidationError) as exc:
             self.validator.validate(dataset)
@@ -259,7 +206,7 @@ class TestSwiftMessagesValidator(DataJuicerTestCaseBase):
 
     def test_empty_messages(self):
         """Test conversation with empty messages"""
-        data = {'messages': []}
+        data = {"messages": []}
         dataset = NestedDataset(datasets.Dataset.from_list([data]))
         with self.assertRaises(DataValidationError) as exc:
             self.validator.validate(dataset)
@@ -269,11 +216,10 @@ class TestSwiftMessagesValidator(DataJuicerTestCaseBase):
         """Test conversation exceeding max_turns"""
         messages = []
         for i in range(6):  # 6 pairs = 12 messages
-            messages.extend([
-                {'role': 'user', 'content': f'user_{i}'},
-                {'role': 'assistant', 'content': f'assistant_{i}'}
-            ])
-        data = {'messages': messages}
+            messages.extend(
+                [{"role": "user", "content": f"user_{i}"}, {"role": "assistant", "content": f"assistant_{i}"}]
+            )
+        data = {"messages": messages}
         dataset = NestedDataset(datasets.Dataset.from_list([data]))
         with self.assertRaises(DataValidationError) as exc:
             self.validator.validate(dataset)
@@ -281,12 +227,7 @@ class TestSwiftMessagesValidator(DataJuicerTestCaseBase):
 
     def test_missing_content(self):
         """Test message with missing content"""
-        data = {
-            'messages': [
-                {'role': 'user'},  # Missing content field
-                {'role': 'assistant', 'content': 'Hi'}
-            ]
-        }
+        data = {"messages": [{"role": "user"}, {"role": "assistant", "content": "Hi"}]}  # Missing content field
         dataset = NestedDataset(datasets.Dataset.from_list([data]))
         with self.assertRaises(DataValidationError) as exc:
             self.validator.validate(dataset)
@@ -294,12 +235,7 @@ class TestSwiftMessagesValidator(DataJuicerTestCaseBase):
 
     def test_missing_role(self):
         """Test message with missing role"""
-        data = {
-            'messages': [
-                {'content': 'Hello'},  # Missing role field
-                {'role': 'assistant', 'content': 'Hi'}
-            ]
-        }
+        data = {"messages": [{"content": "Hello"}, {"role": "assistant", "content": "Hi"}]}  # Missing role field
         dataset = NestedDataset(datasets.Dataset.from_list([data]))
         with self.assertRaises(DataValidationError) as exc:
             self.validator.validate(dataset)
@@ -308,9 +244,9 @@ class TestSwiftMessagesValidator(DataJuicerTestCaseBase):
     def test_invalid_role(self):
         """Test message with invalid role"""
         data = {
-            'messages': [
-                {'role': 'invalid', 'content': 'Hello'},  # Invalid role
-                {'role': 'assistant', 'content': 'Hi'}
+            "messages": [
+                {"role": "invalid", "content": "Hello"},  # Invalid role
+                {"role": "assistant", "content": "Hi"},
             ]
         }
         dataset = NestedDataset(datasets.Dataset.from_list([data]))
@@ -320,12 +256,7 @@ class TestSwiftMessagesValidator(DataJuicerTestCaseBase):
 
     def test_non_string_content(self):
         """Test message with non-string content"""
-        data = {
-            'messages': [
-                {'role': 'user', 'content': 123},
-                {'role': 'assistant', 'content': 'Hi'}
-            ]
-        }
+        data = {"messages": [{"role": "user", "content": 123}, {"role": "assistant", "content": "Hi"}]}
         with self.assertRaises(Exception) as exc:
             # from_list will raise an exception if the content has inconsistent types
             dataset = NestedDataset(datasets.Dataset.from_list([data]))
@@ -337,38 +268,32 @@ class TestDataJuicerFormatValidator(DataJuicerTestCaseBase):
     def setUp(self):
         """Setup test validator"""
         super().setUp()
-        self.config = {'min_turns': 1, 'max_turns': 5}
+        self.config = {"min_turns": 1, "max_turns": 5}
         self.validator = DataJuicerFormatValidator(self.config)
 
     def test_valid_conversation_with_system(self):
         """Test valid conversation with system message"""
         data = {
-            'system': 'Be helpful',
-            'instruction': 'Help me with this',
-            'query': 'How do I code?',
-            'response': 'Here is how...',
-            'history': [
-                ['What is Python?', 'Python is a programming language']
-            ]
+            "system": "Be helpful",
+            "instruction": "Help me with this",
+            "query": "How do I code?",
+            "response": "Here is how...",
+            "history": [["What is Python?", "Python is a programming language"]],
         }
         dataset = NestedDataset(datasets.Dataset.from_list([data]))
         self.validator.validate(dataset)  # Should not raise
 
     def test_valid_conversation_without_system(self):
         """Test valid conversation without optional fields"""
-        data = {
-            'instruction': 'Help me',
-            'query': 'How do I code?',
-            'response': 'Here is how...'
-        }
+        data = {"instruction": "Help me", "query": "How do I code?", "response": "Here is how..."}
         dataset = NestedDataset(datasets.Dataset.from_list([data]))
         self.validator.validate(dataset)  # Should not raise
 
     def test_missing_required_field(self):
         """Test conversation with missing required field"""
         data = {
-            'instruction': 'Help me',
-            'query': 'How do I code?'
+            "instruction": "Help me",
+            "query": "How do I code?",
             # missing 'response'
         }
         dataset = NestedDataset(datasets.Dataset.from_list([data]))
@@ -378,11 +303,7 @@ class TestDataJuicerFormatValidator(DataJuicerTestCaseBase):
 
     def test_invalid_field_type(self):
         """Test conversation with invalid field type"""
-        data = {
-            'instruction': 'Help me',
-            'query': 123,  # should be string
-            'response': 'Here is how...'
-        }
+        data = {"instruction": "Help me", "query": 123, "response": "Here is how..."}  # should be string
         dataset = NestedDataset(datasets.Dataset.from_list([data]))
         with self.assertRaises(DataValidationError) as exc:
             self.validator.validate(dataset)
@@ -391,12 +312,10 @@ class TestDataJuicerFormatValidator(DataJuicerTestCaseBase):
     def test_invalid_history_format(self):
         """Test conversation with invalid history format"""
         data = {
-            'instruction': 'Help me',
-            'query': 'How do I code?',
-            'response': 'Here is how...',
-            'history': [
-                ['Single element']  # should be [query, response] pair
-            ]
+            "instruction": "Help me",
+            "query": "How do I code?",
+            "response": "Here is how...",
+            "history": [["Single element"]],  # should be [query, response] pair
         }
         dataset = NestedDataset(datasets.Dataset.from_list([data]))
         with self.assertRaises(DataValidationError) as exc:
@@ -405,14 +324,14 @@ class TestDataJuicerFormatValidator(DataJuicerTestCaseBase):
 
     def test_too_many_turns(self):
         """Test conversation exceeding max_turns"""
-        history = [['Q1', 'A1'], ['Q2', 'A2'], ['Q3', 'A3'], 
-                  ['Q4', 'A4'], ['Q5', 'A5']]  # 5 history turns + 1 current = 6
-        data = {
-            'instruction': 'Help me',
-            'query': 'How do I code?',
-            'response': 'Here is how...',
-            'history': history
-        }
+        history = [
+            ["Q1", "A1"],
+            ["Q2", "A2"],
+            ["Q3", "A3"],
+            ["Q4", "A4"],
+            ["Q5", "A5"],
+        ]  # 5 history turns + 1 current = 6
+        data = {"instruction": "Help me", "query": "How do I code?", "response": "Here is how...", "history": history}
         dataset = NestedDataset(datasets.Dataset.from_list([data]))
         with self.assertRaises(DataValidationError) as exc:
             self.validator.validate(dataset)
@@ -421,12 +340,10 @@ class TestDataJuicerFormatValidator(DataJuicerTestCaseBase):
     def test_invalid_history_types(self):
         """Test conversation with invalid types in history"""
         data = {
-            'instruction': 'Help me',
-            'query': 'How do I code?',
-            'response': 'Here is how...',
-            'history': [
-                [123, 456]  # query should be string
-            ]
+            "instruction": "Help me",
+            "query": "How do I code?",
+            "response": "Here is how...",
+            "history": [[123, 456]],  # query should be string
         }
 
         with self.assertRaises(DataValidationError) as exc:
@@ -438,10 +355,10 @@ class TestDataJuicerFormatValidator(DataJuicerTestCaseBase):
     def test_invalid_system_type(self):
         """Test conversation with invalid system type"""
         data = {
-            'system': 123,  # should be string
-            'instruction': 'Help me',
-            'query': 'How do I code?',
-            'response': 'Here is how...'
+            "system": 123,  # should be string
+            "instruction": "Help me",
+            "query": "How do I code?",
+            "response": "Here is how...",
         }
         dataset = NestedDataset(datasets.Dataset.from_list([data]))
         with self.assertRaises(DataValidationError) as exc:
@@ -451,11 +368,11 @@ class TestDataJuicerFormatValidator(DataJuicerTestCaseBase):
     def test_invalid_history_array(self):
         """Test valid conversation with system message"""
         data = {
-            'system': 'Be helpful',
-            'instruction': 'Help me with this',
-            'query': 'How do I code?',
-            'response': 'Here is how...',
-            'history': 'history_str',
+            "system": "Be helpful",
+            "instruction": "Help me with this",
+            "query": "How do I code?",
+            "response": "Here is how...",
+            "history": "history_str",
         }
         with self.assertRaises(DataValidationError) as exc:
             # from_list will raise an exception if the content has inconsistent types
@@ -465,14 +382,11 @@ class TestDataJuicerFormatValidator(DataJuicerTestCaseBase):
 
     def test_missing_rate_exceeded(self):
         data = {
-            'instruction': ['Help me with this', 'other inst', None, None, None],
-            'query': ['How do I code?', None, None, None, None],
-            'response': ['Here is how...', 'Here is how...', 'Here is how...', 'Here is how...', 'Here is how...'],
+            "instruction": ["Help me with this", "other inst", None, None, None],
+            "query": ["How do I code?", None, None, None, None],
+            "response": ["Here is how...", "Here is how...", "Here is how...", "Here is how...", "Here is how..."],
         }
-        config = {
-            'required_fields': ['query', 'response'],
-            'allow_missing': .25
-        }
+        config = {"required_fields": ["query", "response"], "allow_missing": 0.25}
         validator = RequiredFieldsValidator(config)
         with self.assertRaises(DataValidationError) as exc:
             # from_list will raise an exception if the content has inconsistent types
@@ -481,5 +395,5 @@ class TestDataJuicerFormatValidator(DataJuicerTestCaseBase):
         self.assertIn("missing values, exceeding allowed", str(exc.exception).lower())
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
  fix: convert string type names to Python types in RequiredFieldsValidator (#796)

  PR Description

  ## Summary

  - Fix TypeError when using `field_types` in YAML config for `RequiredFieldsValidator`
  - Add `TYPE_NAME_MAPPING` to convert string type names (e.g., `'str'`, `'int'`) to Python type objects
  - Add `_normalize_field_types()` method to handle both string and type object specifications
  - Add unit tests for string type names, unknown type names, and invalid type specifications

  ## Problem

  When `field_types` is specified in YAML config as documented in `config_all.yaml`:

  ```yaml
  field_types:
    text: 'str'

  The YAML parser reads 'str' as a string "str" rather than Python's str type. This causes isinstance() in the validation logic to raise:

  TypeError: isinstance() arg 2 must be a type, a tuple of types, or a union

  Solution

  Added a type name mapping and normalization method that converts string type names to actual Python types during validator initialization, while maintaining backward compatibility with direct type object specifications.

  Supported type names: str, string, int, integer, float, bool, boolean, list, dict, tuple, set, bytes

  Test plan

  - Verify fix reproduces and resolves the original issue
  - Add unit tests for string type names from YAML config
  - Add unit tests for unknown type name error handling
  - Add unit tests for invalid type specification error handling
  - Ensure backward compatibility with existing type object specifications

  Fixes: https://github.com/datajuicer/data-juicer/issues/796
