### PR TITLE
fix: replace deprecated 'concurrency' with 'compute' in map_batches call

### DIFF
--- a/data_juicer/ops/deduplicator/ray_bts_minhash_deduplicator.py
+++ b/data_juicer/ops/deduplicator/ray_bts_minhash_deduplicator.py
@@ -729,7 +729,7 @@ class RayBTSMinhashDeduplicator(Deduplicator):
                 batch_format="pyarrow",
                 zero_copy_batch=True,
                 num_gpus=1,
-                concurrency=ray.data.ActorPoolStrategy(size=concurrency),
+                compute=ray.data.ActorPoolStrategy(size=concurrency),
                 batch_size=batch_size,
             )
             dataset.map_batches(band_with_uid, **self._get_map_batches_kwargs()).write_parquet(tmp_dir)


### PR DESCRIPTION
## Description
This PR updates the Ray Data API usage in the RayBTSMinhashDeduplicator to use the current recommended parameter.

## Changes
- Replaced the deprecated `concurrency` parameter with `compute` parameter in the `ray.data.Dataset.map_batches()` call

## Reason
According to the [Ray Data API documentation](https://docs.ray.io/en/latest/data/api/doc/ray.data.Dataset.map_batches.html), the `concurrency` parameter is deprecated and should be replaced with the `compute` parameter for specifying the compute strategy.

## Testing
- The functionality remains the same, just using the updated API parameter name
- `ray.data.ActorPoolStrategy(size=concurrency)` is now passed via `compute` instead of `concurrency`