### PR TITLE
perf: optimize ImageCaptioningMapper with true GPU batching

### DIFF
--- a/data_juicer/ops/mapper/image_captioning_mapper.py
+++ b/data_juicer/ops/mapper/image_captioning_mapper.py
@@ -1,6 +1,6 @@
 import copy
 import random
-from typing import Optional
+from typing import List, Optional, Tuple
 
 import numpy as np
 from loguru import logger
@@ -52,6 +52,7 @@ class ImageCaptioningMapper(Mapper):
         keep_original_sample: bool = True,
         prompt: Optional[str] = None,
         prompt_key: Optional[str] = None,
+        gpu_batch_size: PositiveInt = 8,
         *args,
         **kwargs,
     ):
@@ -93,6 +94,10 @@ class ImageCaptioningMapper(Mapper):
             for each sample. It's used for set different prompts for different
             samples. If it's none, use prompt in parameter "prompt". It's None
             in default.
+        :param gpu_batch_size: the batch size for GPU inference. This controls
+            how many images are processed together in a single GPU forward pass.
+            Useful when the dataset batch size is larger than what the GPU can
+            handle. Default is 8.
         :param args: extra args
         :param kwargs: extra args
         """
@@ -115,6 +120,7 @@ class ImageCaptioningMapper(Mapper):
         self.keep_original_sample = keep_original_sample
         self.prompt = prompt
         self.prompt_key = prompt_key
+        self.gpu_batch_size = gpu_batch_size
         self.extra_args = kwargs
         if keep_candidate_mode in ["random_any", "similar_one_simhash"]:
             self.num_newly_generated_samples = 1
@@ -230,6 +236,15 @@ class ImageCaptioningMapper(Mapper):
         return generated_samples
 
     def _reduce_captions_per_image(self, chunk, generated_text_candidates_single_chunk):
+        """Reduce multiple candidate captions to the final caption(s) for a single image.
+
+        Args:
+            chunk: The text chunk containing the image placeholder.
+            generated_text_candidates_single_chunk: List of candidate captions.
+
+        Returns:
+            List of reduced captions based on keep_candidate_mode.
+        """
         new_generated_text_per_chunk = []
         if self.keep_candidate_mode == "random_any":
             new_generated_text_per_chunk.append(random.choice(generated_text_candidates_single_chunk))
@@ -259,8 +274,174 @@ class ImageCaptioningMapper(Mapper):
             new_generated_text_per_chunk.append(generated_text_candidates_single_chunk[max_index])
         return new_generated_text_per_chunk
 
-    def process_batched(self, samples, rank=None):
+    def _batched_generate(
+        self,
+        images: List,
+        prompts: Optional[List[str]],
+        model,
+        processor,
+    ) -> List[List[str]]:
+        """Generate captions for a batch of images using GPU batching.
+
+        This method processes images in sub-batches of size gpu_batch_size to
+        prevent GPU memory overflow while maximizing throughput.
+
+        Args:
+            images: List of PIL Image objects to generate captions for.
+            prompts: Optional list of prompts, one per image. If None, no prompts
+                are used.
+            model: The HuggingFace model for caption generation.
+            processor: The HuggingFace processor for the model.
+
+        Returns:
+            A 2D list where result[i][j] is the j-th candidate caption for the
+            i-th image. Shape: [num_images, caption_num].
         """
+        if not images:
+            return []
+
+        num_images = len(images)
+        # Initialize result: [num_images][caption_num]
+        all_captions = [[] for _ in range(num_images)]
+
+        # Generate caption_num candidates for each image
+        for caption_idx in range(self.caption_num):
+            # Process images in sub-batches of gpu_batch_size
+            batch_captions = []
+            for batch_start in range(0, num_images, self.gpu_batch_size):
+                batch_end = min(batch_start + self.gpu_batch_size, num_images)
+                batch_images = images[batch_start:batch_end]
+
+                # Handle prompts for this batch
+                # Pass None only when all prompts in batch are None
+                if prompts is None:
+                    batch_prompts = None
+                else:
+                    batch_prompts = prompts[batch_start:batch_end]
+                    if all(p is None for p in batch_prompts):
+                        batch_prompts = None
+
+                # Prepare inputs for the model
+                inputs = processor(images=batch_images, text=batch_prompts, return_tensors="pt").to(model.device)
+
+                # Generate captions
+                generated_ids = model.generate(**inputs, max_new_tokens=128, do_sample=True)
+                generated_texts = processor.batch_decode(generated_ids, skip_special_tokens=True)
+                batch_captions.extend(generated_texts)
+
+            # Distribute this round's captions to each image
+            for img_idx, caption in enumerate(batch_captions):
+                all_captions[img_idx].append(caption)
+
+        return all_captions
+
+    def _distribute_captions(
+        self,
+        all_captions: List[List[str]],
+        image_to_sample_chunk: List[Tuple[int, int, int]],
+        reconstructed_samples: List[dict],
+    ) -> List[dict]:
+        """Distribute generated captions back to samples and create output samples.
+
+        This method takes the flat list of captions generated for all images and
+        distributes them back to their corresponding samples, handling the text
+        assembly with special tokens.
+
+        Args:
+            all_captions: 2D list where all_captions[i][j] is the j-th candidate
+                caption for the i-th image (in flattened order across all samples).
+            image_to_sample_chunk: List of tuples (sample_idx, chunk_idx, image_idx_in_chunk)
+                that maps each image in all_captions back to its source sample and chunk.
+            reconstructed_samples: List of original sample dictionaries.
+
+        Returns:
+            List of generated sample dictionaries with captions inserted.
+        """
+        samples_after_generation = []
+
+        for sample_idx, ori_sample in enumerate(reconstructed_samples):
+            # Add original sample if configured to keep it
+            if self.keep_original_sample:
+                samples_after_generation.append(ori_sample)
+
+            # Skip samples without images
+            if self.image_key not in ori_sample or not ori_sample[self.image_key]:
+                continue
+
+            # Prepare generated sample templates
+            generated_samples = [copy.deepcopy(ori_sample) for _ in range(self.num_newly_generated_samples)]
+            for generated_sample in generated_samples:
+                generated_sample[self.text_key] = ""
+
+            # Get all captions for images in this sample
+            sample_image_captions = [
+                (chunk_idx, img_idx_in_chunk, all_captions[global_img_idx])
+                for global_img_idx, (s_idx, chunk_idx, img_idx_in_chunk) in enumerate(image_to_sample_chunk)
+                if s_idx == sample_idx
+            ]
+
+            # Group captions by chunk
+            chunks = ori_sample[self.text_key].split(SpecialTokens.eoc)
+            chunk_captions = {}  # chunk_idx -> {img_idx_in_chunk -> [captions]}
+            for chunk_idx, img_idx_in_chunk, captions in sample_image_captions:
+                if chunk_idx not in chunk_captions:
+                    chunk_captions[chunk_idx] = {}
+                chunk_captions[chunk_idx][img_idx_in_chunk] = captions
+
+            # Process each chunk
+            for chunk_idx, chunk in enumerate(chunks):
+                # Skip empty chunks
+                if not chunk.strip():
+                    continue
+
+                img_count = chunk.count(SpecialTokens.image)
+                text_with_only_special_tokens = remove_non_special_tokens(chunk)
+
+                # Handle chunks with no images - just preserve special tokens
+                if img_count == 0:
+                    for i in range(self.num_newly_generated_samples):
+                        generated_samples[i][self.text_key] += f"{text_with_only_special_tokens}{SpecialTokens.eoc}"
+                    continue
+
+                # Reduce captions for each image in this chunk
+                new_generated_text_all_images = [[] for _ in range(self.num_newly_generated_samples)]
+
+                for img_idx_in_chunk in range(img_count):
+                    # Get captions for this image
+                    if chunk_idx in chunk_captions and img_idx_in_chunk in chunk_captions[chunk_idx]:
+                        image_candidate_captions = chunk_captions[chunk_idx][img_idx_in_chunk]
+                    else:
+                        # Fallback: no captions available (shouldn't happen normally)
+                        image_candidate_captions = [""] * self.caption_num
+
+                    # Reduce captions based on mode
+                    reduced_captions = self._reduce_captions_per_image(chunk, image_candidate_captions)
+
+                    for i, caption in enumerate(reduced_captions):
+                        new_generated_text_all_images[i].append(caption)
+
+                # Insert captions into generated samples
+                placeholders = [SpecialTokens.image] * img_count
+                for i in range(self.num_newly_generated_samples):
+                    new_text = insert_texts_after_placeholders(
+                        original_string=text_with_only_special_tokens,
+                        placeholders=placeholders,
+                        new_texts=new_generated_text_all_images[i],
+                    )
+                    generated_samples[i][self.text_key] += f"{new_text}{SpecialTokens.eoc}"
+
+            # Add generated samples to output
+            samples_after_generation.extend(generated_samples)
+
+        return samples_after_generation
+
+    def process_batched(self, samples, rank=None):
+        """Process a batch of samples with true GPU batching for caption generation.
+
+        This method collects all images from all samples in the batch, generates
+        captions for them in GPU-efficient sub-batches, and then distributes the
+        captions back to their respective samples.
+
         Note:
             This is a batched_OP, whose input and output type are
             both list. Suppose there are $N$ input sample list with batch
@@ -269,25 +450,96 @@ class ImageCaptioningMapper(Mapper):
             for 'random_any' and 'similar_one' mode,
             and $(1+M)Nb$ for 'all' mode.
 
-        :param samples:
-        :return:
+        Args:
+            samples: Dict of lists containing the batch of samples.
+            rank: Optional GPU rank for distributed processing.
+
+        Returns:
+            Dict of lists containing the processed samples with generated captions.
         """
-        # reconstruct samples from "dict of lists" to "list of dicts"
-        reconstructed_samples = []
-        for i in range(len(samples[self.text_key])):
-            reconstructed_samples.append({key: samples[key][i] for key in samples})
-        samples_after_generation = []
-        # do generation for each sample within the batch
-        for ori_sample in reconstructed_samples:
+        # Reconstruct samples from "dict of lists" to "list of dicts"
+        batch_size = len(samples[self.text_key])
+        reconstructed_samples = [{key: samples[key][i] for key in samples} for i in range(batch_size)]
+
+        # Collect all images and their metadata from all samples
+        all_images = []
+        all_prompts = []
+        # Maps global image index -> (sample_idx, chunk_idx, image_idx_in_chunk)
+        image_to_sample_chunk = []
+
+        for sample_idx, sample in enumerate(reconstructed_samples):
+            # Skip samples without images
+            if self.image_key not in sample or not sample[self.image_key]:
+                continue
+
+            # Load all images for this sample
+            loaded_image_keys = sample[self.image_key]
+            images_cache = {}
+            for image_key in loaded_image_keys:
+                if image_key not in images_cache:
+                    images_cache[image_key] = load_image(image_key)
+
+            # Determine prompt for this sample
+            if self.prompt_key and isinstance(sample.get(self.prompt_key), str):
+                sample_prompt = sample[self.prompt_key]
+            elif self.prompt and isinstance(self.prompt, str):
+                sample_prompt = self.prompt
+            else:
+                sample_prompt = None
+
+            # Process each chunk in the sample's text
+            offset = 0
+            chunks = sample[self.text_key].split(SpecialTokens.eoc)
+            for chunk_idx, chunk in enumerate(chunks):
+                if not chunk.strip():
+                    continue
+
+                img_count = chunk.count(SpecialTokens.image)
+                for img_idx_in_chunk in range(img_count):
+                    image_key = loaded_image_keys[offset + img_idx_in_chunk]
+                    image = images_cache[image_key]
+                    all_images.append(image)
+                    all_prompts.append(sample_prompt)
+                    image_to_sample_chunk.append((sample_idx, chunk_idx, img_idx_in_chunk))
+
+                offset += img_count
+
+        # Handle case where there are no images to process
+        if not all_images:
+            # Just return original samples if keep_original_sample is True
             if self.keep_original_sample:
-                samples_after_generation.append(ori_sample)
-            generated_samples = self._process_single_sample(ori_sample, rank=rank)
-            if len(generated_samples) != 0:
-                samples_after_generation.extend(generated_samples)
-        # reconstruct samples from "list of dicts" to "dict of lists"
+                return samples
+            # Otherwise return empty result
+            keys = samples.keys()
+            return {key: [] for key in keys}
+
+        # Get model and processor
+        model, processor = get_model(self.model_key, rank, self.use_cuda())
+        model.config.image_token_index = 50265
+
+        # Generate captions for all images in batched manner
+        prompts_for_generation = all_prompts if any(p is not None for p in all_prompts) else None
+        all_captions = self._batched_generate(
+            images=all_images,
+            prompts=prompts_for_generation,
+            model=model,
+            processor=processor,
+        )
+
+        # Distribute captions back to samples
+        samples_after_generation = self._distribute_captions(
+            all_captions=all_captions,
+            image_to_sample_chunk=image_to_sample_chunk,
+            reconstructed_samples=reconstructed_samples,
+        )
+
+        # Handle edge case: no samples after generation
+        if not samples_after_generation:
+            keys = samples.keys()
+            return {key: [] for key in keys}
+
+        # Reconstruct samples from "list of dicts" to "dict of lists"
         keys = samples_after_generation[0].keys()
-        res_samples = {}
-        for key in keys:
-            res_samples[key] = [s[key] for s in samples_after_generation]
+        res_samples = {key: [s[key] for s in samples_after_generation] for key in keys}
 
         return res_samples


### PR DESCRIPTION
## Summary
- Add `gpu_batch_size` parameter to control GPU inference batch size, preventing OOM when dataset batch size is large
- Add `_batched_generate()` helper for efficient batch caption generation across all images
- Add `_distribute_captions()` helper to map generated captions back to their source samples
- Rewrite `process_batched()` to collect all images from all samples and process them in GPU-efficient sub-batches
- Handle mixed None prompts in batched generation

## Performance Improvement
The original implementation processed samples one by one, calling `model.generate()` for each sample's images separately. The new implementation:
1. Collects all images from all samples in the batch
2. Processes them together in sub-batches of `gpu_batch_size`
3. Distributes the generated captions back to their respective samples

This reduces GPU kernel launch overhead and improves throughput by maximizing GPU utilization.

## Test plan
- [x] Verify syntax with `python -m py_compile`
- [x] Run existing unit tests: `pytest tests/ops/mapper/test_image_captioning_mapper.py`
- [x] Test with `gpu_batch_size` parameter on GPU environment
- [x] Verify output consistency with original implementation

🤖 Generated with [Claude Code](https://claude.ai/code)