### PR TITLE
perf: skip unnecessary strip() call in should_keep_long_word

### DIFF
--- a/data_juicer/ops/mapper/remove_long_words_mapper.py
+++ b/data_juicer/ops/mapper/remove_long_words_mapper.py
@@ -47,8 +47,7 @@ class RemoveLongWordsMapper(Mapper):
             return True
         # Only strip when word is too long; if too short, stripping won't help
         if word_len > self.max_len:
-            stripped_len = len(strip(word, SPECIAL_CHARACTERS))
-            return self.min_len <= stripped_len <= self.max_len
+            return self.min_len <= len(strip(word, SPECIAL_CHARACTERS)) <= self.max_len
         return False
 
     def process_batched(self, samples):


### PR DESCRIPTION
## Summary
Optimize `should_keep_long_word` method in `RemoveLongWordsMapper` by avoiding unnecessary `strip()` calls.

## Problem
The original code:
```python
def should_keep_long_word(self, word):
    if self.min_len <= len(word) <= self.max_len:
        return True
    elif self.min_len <= len(strip(word, SPECIAL_CHARACTERS)) <= self.max_len:
        return True
    else:
        return False
```

When the first condition fails, there are two cases:
1. `len(word) < min_len`: stripping special characters will only make the word shorter or equal length, **never longer**. So the second condition can never be satisfied.
2. `len(word) > max_len`: stripping might reduce length into valid range, so checking is meaningful.

## Solution
Only call `strip()` when the word is too long:
```python
def should_keep_long_word(self, word):
    word_len = len(word)
    if self.min_len <= word_len <= self.max_len:
        return True
    if word_len > self.max_len:
        stripped_len = len(strip(word, SPECIAL_CHARACTERS))
        return self.min_len <= stripped_len <= self.max_len
    return False
```

## Performance Improvement
- Avoids unnecessary `strip()` calls when `len(word) < min_len`
- Caches `len(word)` to avoid redundant computation

## Test plan
- [x] Verify syntax with `python -m py_compile`
- [x] Run pre-commit checks

🤖 Generated with [Claude Code](https://claude.ai/code)