### PR TITLE
Perf: optimize memory usage in convert_to_absolute_paths

### DIFF
--- a/data_juicer/core/data/ray_dataset.py
+++ b/data_juicer/core/data/ray_dataset.py
@@ -34,17 +34,19 @@ def get_abs_path(path, dataset_dir):
 def convert_to_absolute_paths(samples: pyarrow.Table, dataset_dir, path_keys):
     for key in path_keys:
         col_idx = samples.schema.get_field_index(key)
-        col = samples.column(col_idx)
-        paths = col.to_pylist()
-        new_paths = []
-        for path in paths:
-            if isinstance(path, str):
-                new_paths.append(get_abs_path(path, dataset_dir))
-            elif isinstance(path, list):
-                new_paths.append([get_abs_path(p, dataset_dir) for p in path])
-            else:
-                new_paths.append(path)
-        samples = samples.set_column(col_idx, key, pyarrow.array(new_paths))
+        cols = samples.column(col_idx)
+
+        def _process_paths():
+            for col in cols:
+                path = col.as_py()
+                if isinstance(path, str):
+                    yield get_abs_path(path, dataset_dir)
+                elif isinstance(path, list):
+                    yield [get_abs_path(p, dataset_dir) for p in path]
+                else:
+                    yield path
+
+        samples = samples.set_column(col_idx, key, pyarrow.array(_process_paths()))
     return samples
 
 


### PR DESCRIPTION
**Problem:** The original `convert_to_absolute_paths` implementation uses `samples.to_pydict()`, which triggers a full copy of the pyarrow.Table from shared memory to local memory. When the dataset contains large objects (e.g., image bytes, high-dimensional tensors), this leads to a significant memory spike and potential OOM (Out Of Memory) issues.
```
def convert_to_absolute_paths(samples, dataset_dir, path_keys):
    samples = samples.to_pydict()
    for key in path_keys:
        for idx in range(len(samples[key])):
            paths = samples[key][idx]
            if isinstance(paths, str):
                samples[key][idx] = get_abs_path(paths, dataset_dir)
            elif isinstance(paths, list):
                samples[key][idx] = [get_abs_path(item, dataset_dir) for item in paths]
    return pyarrow.Table.from_pydict(samples)
```
Resource monitoring shows that for a image dataset of 100k samples with image bytes, this worker can consume up to 100GB of memory：
<img width="1024" height="486" alt="image" src="https://github.com/user-attachments/assets/f46d2673-9be6-406a-a133-7306530df9a8" />


**Solution:** Instead of converting the entire table, this PR updates the function to:

- Iterate only over the specific columns defined in `path_keys`.

- Convert only the required columns to lists for path processing.

```
def convert_to_absolute_paths(samples: pyarrow.Table, dataset_dir, path_keys):
    for key in path_keys:
        col_idx = samples.schema.get_field_index(key)
        col = samples.column(col_idx)
        paths = col.to_pylist()
        new_paths = []
        for path in paths:
            if isinstance(path, str):
                new_paths.append(get_abs_path(path, dataset_dir))
            elif isinstance(path, list):
                new_paths.append([get_abs_path(p, dataset_dir) for p in path])
            else:
                new_paths.append(path)
        samples = samples.set_column(col_idx, key, pyarrow.array(new_paths))
    return samples
```

**Impact:**

- Significantly lower memory usage: Non-path columns (which might contain heavy data) remain in shared memory or are handled more efficiently by Arrow.

Memery consumption reduces to 26GB at peak.
<img width="1494" height="1110" alt="image" src="https://github.com/user-attachments/assets/d7de68cf-cd38-4917-b46c-36cd3d576568" />

