### PR TITLE
fix: correct cache key in ImageFaceCountFilter

### DIFF
--- a/data_juicer/ops/filter/image_face_count_filter.py
+++ b/data_juicer/ops/filter/image_face_count_filter.py
@@ -80,7 +80,7 @@ class ImageFaceCountFilter(Filter):
 
     def compute_stats_single(self, sample, context=False):
         # check if it's computed already
-        if StatsKeys.face_ratios in sample[Fields.stats]:
+        if StatsKeys.face_counts in sample[Fields.stats]:
             return sample
 
         # there is no image in this sample


### PR DESCRIPTION
## Summary
Fix a bug in `ImageFaceCountFilter.compute_stats_single()` where the cache key check used `StatsKeys.face_ratios` instead of `StatsKeys.face_counts`.

## Problem
```python
# Line 83 - BEFORE (wrong)
if StatsKeys.face_ratios in sample[Fields.stats]:
    return sample
```

`face_ratios` belongs to `ImageFaceRatioFilter`. This filter stores its results under `face_counts` (line 109), but checks `face_ratios` for cache hits (line 83). As a result, the filter **never** hits its own cache and always recomputes face detection — which involves loading an OpenCV model and running detection on every image.

## Fix
```python
# Line 83 - AFTER (correct)
if StatsKeys.face_counts in sample[Fields.stats]:
    return sample
```

## Impact
- Avoids redundant face detection when `ImageFaceCountFilter` is called multiple times on the same sample
- Particularly impactful in pipelines where the same data passes through multiple processing stages

## Test plan
- [x] Verify syntax with `python -m py_compile`
- [x] Run pre-commit checks

🤖 Generated with [Claude Code](https://claude.ai/code)