### PR TITLE
feat(config): add load_dataset_kwargs for passing extra args to datasets.load_dataset()

### DIFF
--- a/data_juicer/config/config.py
+++ b/data_juicer/config/config.py
@@ -212,6 +212,16 @@ def init_configs(args: Optional[List[str]] = None, which_entry: object = None, l
                 "must have a `type` field specifying the validator type.",
             )
             parser.add_argument(
+                "--load_dataset_kwargs",
+                type=Dict,
+                default={},
+                help="Extra keyword arguments passed through to the underlying "  # noqa: E251
+                "datasets.load_dataset() call. Useful for format-specific "
+                "options such as chunksize (JSON), columns (Parquet), or "
+                "delimiter (CSV). See the HuggingFace Datasets docs for "
+                "available options.",
+            )
+            parser.add_argument(
                 "--work_dir",
                 type=str,
                 default=None,

--- a/data_juicer/config/config_all.yaml
+++ b/data_juicer/config/config_all.yaml
@@ -33,6 +33,7 @@ export_in_parallel: false                                   # whether to export 
 keep_stats_in_res_ds: false                                 # whether to keep the computed stats in the result dataset. The intermediate fields to store the stats computed by Filters will be removed if it's False. It's False in default.
 keep_hashes_in_res_ds: false                                # whether to keep the computed hashes in the result dataset. The intermediate fields to store the hashes computed by Deduplicators will be removed if it's False. It's False in default.
 export_extra_args: {}                                       # Other optional arguments for exporting in dict. For example, the key mapping info for exporting the WebDataset format.
+load_dataset_kwargs: {}                                     # extra kwargs passed to datasets.load_dataset(). Useful for format-specific options, e.g. chunksize (JSON), columns (Parquet), delimiter (CSV).
 
 auto_op_parallelism: true                                   # whether to automatically set num_proc according to system resources. It is true in default.
 np: 4                                                       # number of subprocess to process your dataset

--- a/data_juicer/core/executor/default_executor.py
+++ b/data_juicer/core/executor/default_executor.py
@@ -156,7 +156,10 @@ class DefaultExecutor(ExecutorBase, DAGExecutionMixin, EventLoggingMixin):
             logger.info("Loading dataset from dataset builder...")
             if load_data_np is None:
                 load_data_np = self.np
-            dataset = self.dataset_builder.load_dataset(num_proc=load_data_np)
+            load_kwargs = {"num_proc": load_data_np}
+            if getattr(self.cfg, "load_dataset_kwargs", None):
+                load_kwargs.update(dict(self.cfg.load_dataset_kwargs))
+            dataset = self.dataset_builder.load_dataset(**load_kwargs)
 
         # 2. extract processes and optimize their orders
         logger.info("Preparing process operators...")
@@ -282,7 +285,10 @@ class DefaultExecutor(ExecutorBase, DAGExecutionMixin, EventLoggingMixin):
             logger.info("Loading dataset from dataset builder...")
             if load_data_np is None:
                 load_data_np = self.np
-            dataset = self.dataset_builder.load_dataset(num_proc=load_data_np)
+            load_kwargs = {"num_proc": load_data_np}
+            if getattr(self.cfg, "load_dataset_kwargs", None):
+                load_kwargs.update(dict(self.cfg.load_dataset_kwargs))
+            dataset = self.dataset_builder.load_dataset(**load_kwargs)
 
         # Perform sampling based on the specified algorithm
         if sample_algo == "uniform":

--- a/tests/core/data/test_dataset_builder.py
+++ b/tests/core/data/test_dataset_builder.py
@@ -692,5 +692,32 @@ class DatasetBuilderTest(DataJuicerTestCaseBase):
         self.assertIn('No data validator found', str(context.exception))
 
 
+    def test_load_dataset_forwards_extra_kwargs(self):
+        """Test that extra kwargs are forwarded through load_dataset."""
+        self.base_cfg.dataset = {
+            'configs': [{
+                'type': 'local',
+                'path': 'test_data/sample.jsonl',
+            }],
+        }
+        self.base_cfg.text_keys = ['text']
+        self.base_cfg.process = []
+
+        builder = DatasetBuilder(self.base_cfg, self.executor_type)
+
+        captured_kwargs = {}
+        original_load = builder.load_strategies[0].load_data
+
+        def spy_load_data(**kwargs):
+            captured_kwargs.update(kwargs)
+            return original_load(**kwargs)
+
+        builder.load_strategies[0].load_data = spy_load_data
+        builder.load_dataset(num_proc=1, chunksize=99999)
+
+        self.assertEqual(captured_kwargs['num_proc'], 1)
+        self.assertEqual(captured_kwargs['chunksize'], 99999)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/core/data/test_load_strategy.py
+++ b/tests/core/data/test_load_strategy.py
@@ -3,6 +3,7 @@ from unittest.mock import patch, MagicMock
 from data_juicer.core.data.load_strategy import (
     DataLoadStrategyRegistry, DataLoadStrategy, StrategyKey,
     DefaultLocalDataLoadStrategy,
+    DefaultHuggingfaceDataLoadStrategy,
     RayLocalJsonDataLoadStrategy,
     DefaultS3DataLoadStrategy,
     RayS3DataLoadStrategy
@@ -255,7 +256,57 @@ class DataLoadStrategyRegistryTest(DataJuicerTestCaseBase):
         assert getattr(strategy.cfg, 'text_keys', ['text']) == ['text']
         assert getattr(strategy.cfg, 'suffixes', None) is None
         assert getattr(strategy.cfg, 'add_suffix', False) is False
-        
+
+    def test_local_strategy_forwards_load_dataset_kwargs(self):
+        """Test that extra kwargs passed to load_data reach datasets.load_dataset.
+
+        Passes a ``features`` kwarg that adds an extra column not present in the
+        source file.  If kwargs are forwarded correctly, the loaded dataset will
+        contain that column; if not, it won't.
+        """
+        from datasets import Features, Value
+
+        DataLoadStrategyRegistry._strategies = {}
+
+        sample_path = osp.join(WORK_DIR, "test_data", "sample.jsonl")
+        cfg = Namespace(text_keys=["text"], suffixes=None, process=[])
+        ds_config = {"type": "local", "path": sample_path}
+
+        extra_features = Features({"text": Value("string"), "extra": Value("string")})
+
+        strategy = DefaultLocalDataLoadStrategy(ds_config, cfg)
+        ds = strategy.load_data(num_proc=1, features=extra_features)
+
+        self.assertIn("extra", ds.features)
+
+    @patch("data_juicer.core.data.load_strategy.datasets.load_dataset")
+    def test_huggingface_strategy_forwards_load_dataset_kwargs(self, mock_load_dataset):
+        """Test that extra kwargs passed to load_data reach datasets.load_dataset.
+
+        The HuggingFace strategy calls ``datasets.load_dataset(path, ...)``
+        which requires a real hub dataset, so we mock it and assert the
+        ``features`` kwarg is present in the call.
+        """
+        from datasets import Features, Value
+
+        DataLoadStrategyRegistry._strategies = {}
+
+        cfg = Namespace(text_keys=["text"])
+        ds_config = {"type": "huggingface", "path": "dummy/dataset"}
+
+        mock_dataset = MagicMock()
+        mock_load_dataset.return_value = mock_dataset
+
+        extra_features = Features({"text": Value("string"), "extra": Value("string")})
+
+        strategy = DefaultHuggingfaceDataLoadStrategy(ds_config, cfg)
+
+        with patch("data_juicer.core.data.load_strategy.unify_format") as mock_unify:
+            mock_unify.return_value = mock_dataset
+            strategy.load_data(num_proc=1, features=extra_features)
+
+        self.assertEqual(mock_load_dataset.call_args.kwargs.get("features"), extra_features)
+
 
 class TestRayLocalJsonDataLoadStrategy(DataJuicerTestCaseBase):
     def setUp(self):


### PR DESCRIPTION
## Summary

Add a new `load_dataset_kwargs` config option that forwards arbitrary keyword arguments to the underlying HuggingFace `datasets.load_dataset()` call. This enables users to control format-specific dataset loading behavior (e.g., `chunksize` for JSON, `columns` for Parquet, `delimiter` for CSV) via YAML config without requiring code changes.

Currently, `DefaultExecutor` only passes `num_proc` when loading datasets. There is no way for users to pass additional kwargs through from their config.

## Changes

- **`data_juicer/config/config.py`**
  - Add `--load_dataset_kwargs` argument (type `Dict`, default `{}`) to the argument parser, grouped with other dataset-related options

- **`data_juicer/core/executor/default_executor.py`**
  - In `run()` and `sample_data()`, merge `load_dataset_kwargs` from the config into the kwargs passed to `dataset_builder.load_dataset()`

- **`data_juicer/config/config_all.yaml`**
  - Document the new option in the reference config

- **`tests/core/data/test_dataset_builder.py`**
  - Add `test_load_dataset_forwards_extra_kwargs` to verify that extra kwargs are forwarded through the `DatasetBuilder` -> load strategy -> formatter chain

## Usage

```yaml
# In your Data Juicer YAML config:
load_dataset_kwargs:
  chunksize: 1000000000
```

Or via CLI:

```bash
dj-process --config recipe.yaml --load_dataset_kwargs '{"chunksize": 1000000000}'
```

The kwargs flow through the existing chain:

```
DefaultExecutor.run()
  -> DatasetBuilder.load_dataset(**load_kwargs)
    -> load_strategy.load_data(**kwargs)
      -> load_formatter(**kwargs)
        -> datasets.load_dataset(**self.kwargs)
```