### PR TITLE
perf: cache redundant sum() calls in repetition filters

### DIFF
--- a/data_juicer/ops/filter/character_repetition_filter.py
+++ b/data_juicer/ops/filter/character_repetition_filter.py
@@ -62,16 +62,15 @@ class CharacterRepetitionFilter(Filter):
                 samples_stats[idx][StatsKeys.char_rep_ratio] = 0.0
                 continue
 
-            freq_char_ngrams = sorted(list(freq_char_ngrams.values()), reverse=True)
-            num_no_rep_char_ngrams = len([el for el in freq_char_ngrams if el == 1])
+            freq_char_ngrams = sorted(freq_char_ngrams.values(), reverse=True)
+            num_no_rep_char_ngrams = freq_char_ngrams.count(1)
             num_rep_char_ngrams = min(
                 int(np.sqrt(len(freq_char_ngrams))),
                 len(freq_char_ngrams) - num_no_rep_char_ngrams,
             )
+            total = sum(freq_char_ngrams)
             samples_stats[idx][StatsKeys.char_rep_ratio] = (
-                (sum(freq_char_ngrams[:num_rep_char_ngrams]) / sum(freq_char_ngrams))
-                if sum(freq_char_ngrams) != 0
-                else 0.0
+                (sum(freq_char_ngrams[:num_rep_char_ngrams]) / total) if total != 0 else 0.0
             )
 
         return samples

--- a/data_juicer/ops/filter/word_repetition_filter.py
+++ b/data_juicer/ops/filter/word_repetition_filter.py
@@ -103,9 +103,8 @@ class WordRepetitionFilter(Filter):
 
             freq_word_ngrams = list(freq_word_ngrams.values())
             rep_more_than_one = [freq for freq in freq_word_ngrams if freq > 1]
-            samples_stats[idx][StatsKeys.word_rep_ratio] = (
-                (sum(rep_more_than_one) / sum(freq_word_ngrams)) if sum(freq_word_ngrams) != 0 else 0.0
-            )
+            total = sum(freq_word_ngrams)
+            samples_stats[idx][StatsKeys.word_rep_ratio] = (sum(rep_more_than_one) / total) if total != 0 else 0.0
 
         return samples
 


### PR DESCRIPTION
## Summary
Eliminate redundant `sum()` computations in `CharacterRepetitionFilter` and `WordRepetitionFilter`.

## Problem

### character_repetition_filter.py (line 71-74)
```python
# BEFORE: sum(freq_char_ngrams) computed twice — O(n) each time
samples_stats[idx][StatsKeys.char_rep_ratio] = (
    (sum(freq_char_ngrams[:num_rep_char_ngrams]) / sum(freq_char_ngrams))
    if sum(freq_char_ngrams) != 0
    else 0.0
)
```

Additional issues on line 65-66:
- `sorted(list(values))` — `list()` is redundant since `sorted()` accepts any iterable
- `len([el for el in freq_char_ngrams if el == 1])` — creates a temporary list just to count; `list.count(1)` is more efficient

### word_repetition_filter.py (line 106-107)
```python
# BEFORE: sum(freq_word_ngrams) computed twice — O(n) each time
samples_stats[idx][StatsKeys.word_rep_ratio] = (
    (sum(rep_more_than_one) / sum(freq_word_ngrams)) if sum(freq_word_ngrams) != 0 else 0.0
)
```

## Fix
Cache the `sum()` result into a local variable `total`:
```python
total = sum(freq_char_ngrams)
... / total if total != 0 else 0.0
```

## Test plan
- [x] Verify syntax with `python -m py_compile`
- [x] Run pre-commit checks

🤖 Generated with [Claude Code](https://claude.ai/code)